### PR TITLE
Support for secure / kerberized clusters

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -3,3 +3,30 @@
 ****************
 Configuring Ibis
 ****************
+
+
+Working with secure clusters (Kerberos)
+---------------------------------------
+
+Ibis is compatible with Hadoop clusters that are secured with Kerberos (as well
+as SSL and LDAP).  Just like the Impala shell and ODBC/JDBC connectors, Ibis
+connects to Impala through the HiveServer2 interface (using the impyla client).
+Therefore, the connection semantics are similar to the other access methods for
+working with secure clusters.
+
+Specifically, after authenticating yourself against Kerberos (e.g., by issuing
+the appropriate ``kinit`` commmand), simply pass ``use_kerberos=True`` (and set
+``kerberos_service_name`` if necessary) to the ``ibis.impala_connect(...)``
+method when instantiating an ``ImpalaConnection``.  This method also takes
+arguments to configure LDAP (``use_ldap``, ``ldap_user``, and
+``ldap_password``) and SSL (``use_ssl``, ``ca_cert``).  See the documentation
+for the Impala shell for more details.
+
+Ibis also includes functionality that communicates directly with HDFS, using
+the WebHDFS REST API.  When calling ``ibis.hdfs_connect(...)``, also pass
+``use_kerberos=True``, and ensure that you are connecting to the correct port,
+which may likely be an SSL-secured WebHDFS port.  Also note that you can pass
+``verify=False`` to avoid verifying SSL certificates (which may be helpful in
+testing).  Ibis will assume ``https`` when connecting to a Kerberized cluster.
+Because some Ibis commands create HDFS directories as well as new Impala
+databases and/or tables, your user will require the necessary privileges.

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -49,9 +49,10 @@ the client using ``ibis.make_client``:
 
    con = ibis.make_client(ic, hdfs_client=hdfs)
 
-Depending on your cluster setup, this may be more complicated, especially if
-LDAP or Kerberos is involved. See the :ref:`API reference <api.client>` for
-more.
+Both method calls can take ``use_kerberos=True`` to connect to Kerberos
+clusters.  Depending on your cluster setup, this may also include LDAP or SSL.
+See the :ref:`API reference <api.client>` for more, along with the Impala shell
+reference, as the connection semantics are identical.
 
 Learning resources
 ------------------

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -109,6 +109,9 @@ def hdfs_connect(host='localhost', port=50070, protocol='webhdfs',
     host : string
     port : int, default 50070 (webhdfs default)
     protocol : {'webhdfs'}
+    use_kerberos : boolean, default False
+    verify : boolean, default False
+        Set to False to turn off verifying SSL certificates
 
     Returns
     -------

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -99,7 +99,8 @@ def impala_connect(host='localhost', port=21050, protocol='hiveserver2',
     return ImpalaConnection(pool_size=pool_size, **params)
 
 
-def hdfs_connect(host='localhost', port=50070, protocol='webhdfs', **kwds):
+def hdfs_connect(host='localhost', port=50070, protocol='webhdfs',
+                 use_kerberos=False, verify=True, **kwds):
     """
     Connect to HDFS
 
@@ -113,10 +114,16 @@ def hdfs_connect(host='localhost', port=50070, protocol='webhdfs', **kwds):
     -------
     client : ibis HDFS client
     """
-    from hdfs import InsecureClient
-    url = 'http://{0}:{1}'.format(host, port)
-    client = InsecureClient(url, **kwds)
-    return WebHDFS(client)
+    if use_kerberos:
+        from hdfs.ext.kerberos import KerberosClient
+        url = 'https://{0}:{1}'.format(host, port) # note SSL
+        hdfs_client = KerberosClient(url, mutual_auth='OPTIONAL',
+                                     verify=verify)
+    else:
+        from hdfs.client import InsecureClient
+        url = 'http://{0}:{1}'.format(host, port)
+        hdfs_client = InsecureClient(url, verify=verify)
+    return WebHDFS(hdfs_client)
 
 
 def test(include_e2e=False):

--- a/ibis/tests/test_filesystems.py
+++ b/ibis/tests/test_filesystems.py
@@ -19,13 +19,13 @@ from os import path as osp
 import os
 import shutil
 
-from hdfs import InsecureClient
 import pytest
 
 from ibis.filesystems import HDFS, WebHDFS
 from ibis.compat import unittest
 from ibis.tests.util import IbisTestEnv
 import ibis.util as util
+import ibis
 
 
 ENV = IbisTestEnv()
@@ -77,8 +77,12 @@ class TestHDFSE2E(unittest.TestCase):
     def setUpClass(cls):
         cls.ENV = ENV
         cls.tmp_dir = pjoin(cls.ENV.tmp_dir, util.guid())
-        cls.hdfs_client = InsecureClient(cls.ENV.hdfs_url)
-        cls.hdfs = WebHDFS(cls.hdfs_client)
+        if cls.ENV.use_kerberos:
+            print("Warning: ignoring invalid Certificate Authority errors")
+        cls.hdfs = ibis.hdfs_connect(host=cls.ENV.nn_host,
+                                     port=cls.ENV.webhdfs_port,
+                                     use_kerberos=cls.ENV.use_kerberos,
+                                     verify=(not cls.ENV.use_kerberos))
         cls.hdfs.mkdir(cls.tmp_dir)
 
     @classmethod

--- a/scripts/cleanup_testing_data.py
+++ b/scripts/cleanup_testing_data.py
@@ -35,8 +35,13 @@ ENV = IbisTestEnv()
 
 def make_connection():
     ic = ibis.impala_connect(host=ENV.impala_host, port=ENV.impala_port,
-                             protocol=ENV.impala_protocol)
-    hdfs = ibis.hdfs_connect(host=ENV.nn_host, port=ENV.webhdfs_port)
+                             protocol=ENV.impala_protocol,
+                             use_kerberos=ENV.use_kerberos)
+    if ENV.use_kerberos:
+        print("Warning: ignoring invalid Certificate Authority errors")
+    hdfs = ibis.hdfs_connect(host=ENV.nn_host, port=ENV.webhdfs_port,
+                             use_kerberos=ENV.use_kerberos,
+                             verify=(not ENV.use_kerberos))
     return ibis.make_client(ic, hdfs_client=hdfs)
 
 

--- a/scripts/create_test_data_archive.py
+++ b/scripts/create_test_data_archive.py
@@ -40,8 +40,13 @@ IBIS_TEST_DATA_LOCAL_DIR = 'ibis-testing-data'
 
 def make_connection():
     ic = ibis.impala_connect(host=ENV.impala_host, port=ENV.impala_port,
-                             protocol=ENV.impala_protocol)
-    hdfs = ibis.hdfs_connect(host=ENV.nn_host, port=ENV.webhdfs_port)
+                             protocol=ENV.impala_protocol,
+                             use_kerberos=ENV.use_kerberos)
+    if ENV.use_kerberos:
+        print("Warning: ignoring invalid Certificate Authority errors")
+    hdfs = ibis.hdfs_connect(host=ENV.nn_host, port=ENV.webhdfs_port,
+                             use_kerberos=ENV.use_kerberos,
+                             verify=(not ENV.use_kerberos))
     return ibis.make_client(ic, hdfs_client=hdfs)
 
 

--- a/scripts/load_test_data.py
+++ b/scripts/load_test_data.py
@@ -37,8 +37,13 @@ IBIS_TEST_DATA_URL = ('https://ibis-test-resources.s3.amazonaws.com/'
 
 def make_connection():
     ic = ibis.impala_connect(host=ENV.impala_host, port=ENV.impala_port,
-                             protocol=ENV.impala_protocol)
-    hdfs = ibis.hdfs_connect(host=ENV.nn_host, port=ENV.webhdfs_port)
+                             protocol=ENV.impala_protocol,
+                             use_kerberos=ENV.use_kerberos)
+    if ENV.use_kerberos:
+        print("Warning: ignoring invalid Certificate Authority errors")
+    hdfs = ibis.hdfs_connect(host=ENV.nn_host, port=ENV.webhdfs_port,
+                             use_kerberos=ENV.use_kerberos,
+                             verify=(not ENV.use_kerberos))
     return ibis.make_client(ic, hdfs_client=hdfs)
 
 

--- a/scripts/run_jenkins.sh
+++ b/scripts/run_jenkins.sh
@@ -61,6 +61,18 @@ pip install $IBIS_HOME
 python --version
 which python
 
+if [ $IBIS_TEST_USE_KERBEROS = "True" ]; then
+    pip install git+https://github.com/laserson/python-sasl.git@cython
+
+    # CLOUDERA INTERNAL JENKINS/KERBEROS CONFIG
+    kinit -l 4h -kt /cdep/keytabs/hive.keytab hive
+    sudo -u hive PYTHON_EGG_CACHE=/dev/null impala-shell -k -q "GRANT ALL ON SERVER TO ROLE cdep_default_admin WITH GRANT OPTION"
+    sudo -u hive PYTHON_EGG_CACHE=/dev/null impala-shell -k -q "GRANT ALL ON DATABASE $IBIS_TEST_DATA_DB TO ROLE cdep_default_admin"
+    sudo -u hive PYTHON_EGG_CACHE=/dev/null impala-shell -k -q "GRANT ALL ON DATABASE $IBIS_TEST_TMP_DB TO ROLE cdep_default_admin"
+    kdestroy
+    kinit -l 4h -kt /cdep/keytabs/systest.keytab systest
+fi
+
 cd $IBIS_HOME
 
 python -c "from ibis.tests.util import IbisTestEnv; print(IbisTestEnv())"


### PR DESCRIPTION
This patch makes our test suite pass against a kerberized cluster.  cc @caseyching for review.

Related: #366, #406