### PR TITLE
ENH: don't require kerberos libraries by default

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -18,11 +18,6 @@ System dependencies
 Ibis requires a working Python 2.6 or 2.7 installation (3.x support will come
 in a future release). We recommend `Anaconda <http://continuum.io/downloads>`_.
 
-Some platforms will require that you have Kerberos installed to build properly.
-
-* Redhat / CentOS: ``yum install krb5-devel``
-* Ubuntu / Debian: ``apt-get install libkrb5-dev``
-
 Installing the Python package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -33,6 +28,17 @@ Install ibis using ``pip`` (or ``conda``, whenever it becomes available):
   pip install ibis-framework
 
 This installs the ``ibis`` library to your configured Python environment.
+
+Ibis can also be installed with Kerberos support for its HDFS functionality:
+
+::
+
+  pip install ibis-framework[kerberos]
+
+Some platforms will require that you have Kerberos installed to build properly.
+
+* Redhat / CentOS: ``yum install krb5-devel``
+* Ubuntu / Debian: ``apt-get install libkrb5-dev``
 
 Creating a client
 -----------------

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -19,6 +19,7 @@ __version__ = '0.3.0'
 
 from ibis.client import ImpalaConnection, ImpalaClient
 from ibis.filesystems import HDFS, WebHDFS
+from ibis.common import IbisError
 
 import ibis.expr.api as api
 import ibis.expr.types as ir
@@ -118,6 +119,13 @@ def hdfs_connect(host='localhost', port=50070, protocol='webhdfs',
     client : ibis HDFS client
     """
     if use_kerberos:
+        try:
+            import requests_kerberos
+        except ImportError:
+            raise IbisError(
+                "Unable to import requests-kerberos, which is required for "
+                "Kerberos HDFS support. Install it by executing `pip install "
+                "requests-kerberos` or `pip install hdfs[kerberos]`.")
         from hdfs.ext.kerberos import KerberosClient
         url = 'https://{0}:{1}'.format(host, port) # note SSL
         hdfs_client = KerberosClient(url, mutual_auth='OPTIONAL',

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pandas>=0.12.0
 impyla>=0.9.1
 psutil==0.6.1
 snakebite
-hdfs[kerberos]>=1.1.1
+hdfs>=1.1.1
 six

--- a/scripts/run_jenkins.sh
+++ b/scripts/run_jenkins.sh
@@ -71,6 +71,7 @@ python --version
 which python
 
 if [ $IBIS_TEST_USE_KERBEROS = "True" ]; then
+    pip install requests-kerberos
     pip install git+https://github.com/laserson/python-sasl.git@cython
 
     # CLOUDERA INTERNAL JENKINS/KERBEROS CONFIG

--- a/scripts/run_jenkins.sh
+++ b/scripts/run_jenkins.sh
@@ -54,6 +54,8 @@ if [ -n "$GITHUB_PR" ]; then
     popd
 fi
 
+git status
+
 # Setup Python
 curl https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh > miniconda.sh
 bash miniconda.sh -b -p $TMP_DIR/miniconda

--- a/scripts/run_jenkins.sh
+++ b/scripts/run_jenkins.sh
@@ -54,7 +54,7 @@ if [ -n "$GITHUB_PR" ]; then
     popd
 fi
 
-git status
+pushd $IBIS_HOME && git status && popd
 
 # Setup Python
 curl https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh > miniconda.sh

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,7 @@ setup(
     ext_modules=extensions,
     cmdclass=cmdclass,
     install_requires=requirements,
+    extras_require={'kerberos': ['requests-kerberos']},
     description="Productivity-centric Python Big Data Framework",
     long_description=LONG_DESCRIPTION,
     classifiers=CLASSIFIERS,


### PR DESCRIPTION
Ibis no longer requires installation of Kerberos libraries (through the original `hdfs[kerberos]` dep which required `requests_kerberos`).

Fixes #453.