### PR TITLE
BUG: fix materialized join handling in SQL translator

### DIFF
--- a/ibis/sql/ddl.py
+++ b/ibis/sql/ddl.py
@@ -177,7 +177,10 @@ class Select(DDLStatement):
             elif isinstance(expr, ir.TableExpr):
                 # A * selection, possibly prefixed
                 if context.need_aliases():
-                    expr_str = '{0}.*'.format(context.get_alias(expr))
+                    alias = context.get_alias(expr)
+
+                    # materialized join will not have an alias. see #491
+                    expr_str = '{0}.*'.format(alias) if alias else '*'
                 else:
                     expr_str = '*'
             formatted.append(expr_str)


### PR DESCRIPTION
Inserting a slight hack here, but fully-materialized-joins (equivalent of a `SELECT *` on top of a series of joins)  were handled incorrectly and would fail to generate valid SQL with more than 2 tables in the join. 