### PR TITLE
Fix conda recipe for Windows build

### DIFF
--- a/conda-recipes/ibis-framework/bld.bat
+++ b/conda-recipes/ibis-framework/bld.bat
@@ -1,4 +1,4 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
 if errorlevel 1 exit 1
 
 :: Add more build steps here, if they are necessary.


### PR DESCRIPTION
Sync Windows build script options with Linux/OS X build script options.

Packages can be tested by running the following on Windows:

```
conda install -c koverholt ibis-framework
```