### PR TITLE
Generalize top-k expressions and make them executable

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -702,7 +702,7 @@ class FilterValidator(ExprValidator):
                 if isinstance(arg, ir.ScalarExpr):
                     # arg_valid = True
                     pass
-                elif isinstance(arg, ir.ArrayExpr):
+                elif isinstance(arg, (ir.ArrayExpr, ir.AnalyticExpr)):
                     roots_valid.append(self.shares_some_roots(arg))
                 elif isinstance(arg, ir.Expr):
                     raise NotImplementedError
@@ -713,17 +713,6 @@ class FilterValidator(ExprValidator):
             is_valid = any(roots_valid)
 
         return is_valid
-
-
-def find_base_table(expr):
-    if isinstance(expr, ir.TableExpr):
-        return expr
-
-    for arg in expr.op().flat_args():
-        if isinstance(arg, ir.Expr):
-            r = find_base_table(arg)
-            if isinstance(r, ir.TableExpr):
-                return r
 
 
 def find_source_table(expr):

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -197,7 +197,7 @@ class ExprSimplifier(object):
 
         op = expr.op()
 
-        if isinstance(op, (ops.ValueNode, ops.ArrayNode)):
+        if isinstance(op, ops.ValueNode):
             return self._sub(expr, block=block)
         elif isinstance(op, ops.Filter):
             result = self.lift(op.table, block=block)

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -549,7 +549,7 @@ def value_counts(arg, metric_name='count'):
     counts : TableExpr
       Aggregated table
     """
-    base = _L.find_base_table(arg)
+    base = ir.find_base_table(arg)
     metric = base.count().name(metric_name)
 
     try:
@@ -1646,7 +1646,13 @@ def filter(table, predicates):
 
     predicates = [ir.bind_expr(table, x) for x in predicates]
 
-    op = _L.apply_filter(table, predicates)
+    resolved_predicates = []
+    for pred in predicates:
+        if isinstance(pred, ir.AnalyticExpr):
+            pred = pred.to_filter()
+        resolved_predicates.append(pred)
+
+    op = _L.apply_filter(table, resolved_predicates)
     return TableExpr(op)
 
 

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -231,7 +231,7 @@ class ExprFormatter(object):
             return 'table'
         elif isinstance(expr, ir.ArrayExpr):
             return 'array(%s)' % expr.type()
-        elif isinstance(expr, ir.ScalarExpr):
+        elif isinstance(expr, (ir.ScalarExpr, ir.AnalyticExpr)):
             return '%s' % expr.type()
         elif isinstance(expr, ir.ExprList):
             list_args = [self._get_type_display(arg)

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -18,7 +18,7 @@ from ibis.compat import py_string
 from ibis.expr.rules import value, string, number, integer, boolean, list_of
 from ibis.expr.types import (Node, as_value_expr,
                              ValueExpr, ArrayExpr, TableExpr,
-                             ArrayNode, TableNode, ValueNode,
+                             TableNode, ValueNode,
                              HasSchema, _safe_repr)
 import ibis.common as com
 import ibis.expr.rules as rules
@@ -94,7 +94,7 @@ class SQLQueryResult(ir.BlockingTableNode, HasSchema):
         HasSchema.__init__(self, schema)
 
 
-class TableColumn(ArrayNode):
+class TableColumn(ValueNode):
 
     """
     Selects a column from a TableExpr
@@ -124,7 +124,7 @@ class TableColumn(ArrayNode):
         return klass(self, name=self.name)
 
 
-class TableArrayView(ArrayNode):
+class TableArrayView(ValueNode):
 
     """
     (Temporary?) Helper operation class for SQL translation (fully formed table
@@ -742,7 +742,7 @@ class WindowOp(ValueOp):
         if not is_analytic(expr):
             raise com.IbisInputError('Expression does not contain a valid '
                                      'window operation')
-        ValueNode.__init__(self, expr, window)
+        ValueOp.__init__(self, expr, window)
 
     def over(self, window):
         existing_window = self.args[1]
@@ -968,7 +968,7 @@ class Distinct(ir.BlockingTableNode, ir.HasSchema):
         HasSchema.__init__(self, schema)
 
 
-class DistinctArray(ArrayNode):
+class DistinctArray(ValueNode):
 
     """
     COUNT(DISTINCT ...) is really just syntactic suger, but we provide a
@@ -981,7 +981,7 @@ class DistinctArray(ArrayNode):
 
     def __init__(self, arg):
         self.arg = arg
-        ArrayNode.__init__(self, arg)
+        ValueNode.__init__(self, arg)
 
     def output_type(self):
         return type(self.arg)
@@ -1886,7 +1886,7 @@ class NotContains(Contains):
     pass
 
 
-class ReplaceValues(ArrayNode):
+class ReplaceValues(ValueNode):
 
     """
     Apply a multi-value replacement on a particular column. As an example from
@@ -1896,7 +1896,7 @@ class ReplaceValues(ArrayNode):
     pass
 
 
-class TopK(ArrayNode):
+class TopK(ValueNode):
 
     # Substitutions under TopK are not allowed
     blocking = True

--- a/ibis/expr/tests/test_analytics.py
+++ b/ibis/expr/tests/test_analytics.py
@@ -77,6 +77,5 @@ class TestAnalytics(unittest.TestCase):
         delay_filter = t.dest.topk(10, by=t.arrdelay.mean())
         filtered = t.filter([delay_filter])
 
-        # predicate is unmodified by analysis
         post_pred = filtered.op().predicates[1]
-        assert delay_filter.equals(post_pred)
+        assert delay_filter.to_filter().equals(post_pred)

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -1432,25 +1432,11 @@ class NullLiteral(ValueNode):
         return []
 
 
-class ArrayNode(ValueNode):
-
-    def __init__(self, expr):
-        assert isinstance(expr, ArrayExpr)
-        ValueNode.__init__(self, expr)
-
-    def output_type(self):
-        return NotImplementedError
-
-    def to_expr(self):
-        klass = self.output_type()
-        return klass(self)
-
-
 class ListExpr(ArrayExpr, AnyValue):
     pass
 
 
-class ValueList(ArrayNode):
+class ValueList(ValueNode):
 
     """
     Data structure for a list of value expressions
@@ -1458,7 +1444,7 @@ class ValueList(ArrayNode):
 
     def __init__(self, args):
         self.values = [as_value_expr(x) for x in args]
-        Node.__init__(self, [self.values])
+        ValueNode.__init__(self, [self.values])
 
     def root_tables(self):
         return distinct_roots(*self.values)

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -347,28 +347,20 @@ class SelectBuilder(object):
         return transform.get_result()
     _visit_filter_NotAny = _visit_filter_Any
 
-    def _visit_filter_TopK(self, expr):
+    def _visit_filter_SummaryFilter(self, expr):
         # Top K is rewritten as an
         # - aggregation
         # - sort by
         # - limit
         # - left semi join with table set
-
         metric_name = '__tmp__'
 
-        op = expr.op()
+        parent_op = expr.op()
+        summary_expr = parent_op.args[0]
+        op = summary_expr.op()
 
-        metrics = [op.by.name(metric_name)]
-
-        arg_table = L.find_base_table(op.arg)
-        by_table = L.find_base_table(op.by)
-
-        if arg_table.equals(by_table):
-            agg = arg_table.aggregate(metrics, by=[op.arg])
-        else:
-            agg = self.table_set.aggregate(metrics, by=[op.arg])
-
-        rank_set = agg.sort_by([(metric_name, False)]).limit(op.k)
+        rank_set = op.to_aggregation(metric_name=metric_name,
+                                     parent_table=self.table_set)
 
         pred = (op.arg == getattr(rank_set, op.arg.get_name()))
         self.table_set = self.table_set.semi_join(rank_set, [pred])
@@ -800,7 +792,7 @@ def _adapt_expr(expr):
             table_expr = _reduction_to_aggregation(expr, agg_name='tmp')
             return table_expr, scalar_handler
         else:
-            base_table = L.find_base_table(expr)
+            base_table = ir.find_base_table(expr)
             if base_table is None:
                 # expr with no table refs
                 return expr.name('tmp'), scalar_handler
@@ -820,7 +812,7 @@ def _adapt_expr(expr):
                 any_aggregation = True
 
         if is_aggregation:
-            table = L.find_base_table(exprs[0])
+            table = ir.find_base_table(exprs[0])
             return table.aggregate(exprs), as_is
         elif not any_aggregation:
             return expr, as_is
@@ -858,9 +850,10 @@ def _adapt_expr(expr):
 
         return table_expr, result_handler
     else:
-        raise NotImplementedError
+        raise com.TranslationError('Do not know how to execute: {0}'
+                                   .format(type(expr)))
 
 
 def _reduction_to_aggregation(expr, agg_name='tmp'):
-    table = L.find_base_table(expr)
+    table = ir.find_base_table(expr)
     return table.aggregate([expr.name(agg_name)])

--- a/ibis/sql/exprs.py
+++ b/ibis/sql/exprs.py
@@ -297,13 +297,13 @@ def _notany_expand(expr):
 
 def _all_expand(expr):
     arg = expr.op().args[0]
-    t = L.find_base_table(arg)
+    t = ir.find_base_table(arg)
     return arg.sum() == t.count()
 
 
 def _notall_expand(expr):
     arg = expr.op().args[0]
-    t = L.find_base_table(arg)
+    t = ir.find_base_table(arg)
     return arg.sum() < t.count()
 
 


### PR DESCRIPTION
This also adds the notion of a more general `AnalyticExpr`. Before, `TopK` was yielding a `BooleanArray` which made execution-as-aggregation a little awkward. I'm hoping this opens up to more generalization in contextual analytic expressions. Close #392 and #91. 