### PR TITLE
Enrich data types and schemas, add schema validation to Client.insert

### DIFF
--- a/ibis/client.py
+++ b/ibis/client.py
@@ -29,6 +29,7 @@ from ibis.config import options
 from ibis.filesystems import HDFS, WebHDFS
 
 import ibis.common as com
+import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
 import ibis.sql.compiler as sql
@@ -1267,7 +1268,7 @@ class ImpalaClient(SQLClient):
 
             if typename == 'decimal':
                 precision, scale = col[4:6]
-                adapted_types.append(ir.DecimalType(precision, scale))
+                adapted_types.append(dt.Decimal(precision, scale))
             else:
                 adapted_types.append(typename)
         return names, adapted_types

--- a/ibis/compat.py
+++ b/ibis/compat.py
@@ -15,7 +15,7 @@
 # flake8: noqa
 
 import sys
-from six import BytesIO
+from six import BytesIO, string_types as py_string
 
 
 PY26 = sys.version_info[0] == 2 and sys.version_info[1] == 6
@@ -25,6 +25,3 @@ if PY26:
     import unittest2 as unittest
 else:
     import unittest
-
-
-py_string = basestring

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from ibis.common import RelationError, ExpressionError
+from ibis.expr.datatypes import HasSchema
 from ibis.expr.window import window
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
@@ -205,7 +206,7 @@ class ExprSimplifier(object):
             result = self._lift_Projection(expr, block=block)
         elif isinstance(op, ops.Join):
             result = self._lift_Join(expr, block=block)
-        elif isinstance(op, (ops.TableNode, ir.HasSchema)):
+        elif isinstance(op, (ops.TableNode, HasSchema)):
             return expr
         else:
             raise NotImplementedError

--- a/ibis/expr/analytics.py
+++ b/ibis/expr/analytics.py
@@ -32,7 +32,7 @@ class BucketLike(ir.ValueNode):
         return None
 
     def output_type(self):
-        ctype = dt.CategoryType(self.nbuckets)
+        ctype = dt.Category(self.nbuckets)
         return ctype.array_ctor()
 
 
@@ -90,7 +90,7 @@ class Histogram(BucketLike):
 
     def output_type(self):
         # always undefined cardinality (for now)
-        ctype = dt.CategoryType()
+        ctype = dt.Category()
         return ctype.array_ctor()
 
 

--- a/ibis/expr/analytics.py
+++ b/ibis/expr/analytics.py
@@ -33,7 +33,7 @@ class BucketLike(ir.ValueNode):
 
     def output_type(self):
         ctype = dt.Category(self.nbuckets)
-        return ctype.array_ctor()
+        return ctype.array_type()
 
 
 class Bucket(BucketLike):
@@ -91,7 +91,7 @@ class Histogram(BucketLike):
     def output_type(self):
         # always undefined cardinality (for now)
         ctype = dt.Category()
-        return ctype.array_ctor()
+        return ctype.array_type()
 
 
 class CategoryLabel(ir.ValueNode):

--- a/ibis/expr/analytics.py
+++ b/ibis/expr/analytics.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 import ibis.expr.rules as rules
 import ibis.expr.operations as ops
@@ -31,7 +32,7 @@ class BucketLike(ir.ValueNode):
         return None
 
     def output_type(self):
-        ctype = ir.CategoryType(self.nbuckets)
+        ctype = dt.CategoryType(self.nbuckets)
         return ctype.array_ctor()
 
 
@@ -89,7 +90,7 @@ class Histogram(BucketLike):
 
     def output_type(self):
         # always undefined cardinality (for now)
-        ctype = ir.CategoryType()
+        ctype = dt.CategoryType()
         return ctype.array_ctor()
 
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -108,11 +108,11 @@ def table(schema, name=None):
     -------
     table : TableExpr
     """
-    if not isinstance(schema, ir.Schema):
+    if not isinstance(schema, Schema):
         if isinstance(schema, list):
-            schema = ir.Schema.from_tuples(schema)
+            schema = Schema.from_tuples(schema)
         else:
-            schema = ir.Schema.from_dict(schema)
+            schema = Schema.from_dict(schema)
 
     node = _ops.UnboundTable(schema, name=name)
     return TableExpr(node)

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ibis.expr.types import (Schema, Expr,  # noqa
+from ibis.expr.datatypes import Schema  # noqa
+from ibis.expr.types import (Expr,  # noqa
                              ValueExpr, ScalarExpr, ArrayExpr,
                              TableExpr,
                              NumericValue, NumericArray,

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -92,7 +92,55 @@ class DataType(object):
     pass
 
 
-class DecimalType(DataType):
+class Boolean(DataType):
+    pass
+
+
+class Integer(DataType):
+    pass
+
+
+class String(DataType):
+    pass
+
+
+class Timestamp(DataType):
+    pass
+
+
+class SignedInteger(Integer):
+    pass
+
+
+class Floating(DataType):
+    pass
+
+
+class Int8(Integer):
+    pass
+
+
+class Int16(Integer):
+    pass
+
+
+class Int32(Integer):
+    pass
+
+
+class Int64(Integer):
+    pass
+
+
+class Float32(Integer):
+    pass
+
+
+class Float64(Integer):
+    pass
+
+
+class Decimal(DataType):
     # Decimal types are parametric, we store the parameters in this object
 
     def __init__(self, precision, scale):
@@ -113,7 +161,7 @@ class DecimalType(DataType):
         return not self.__eq__(other)
 
     def __eq__(self, other):
-        if not isinstance(other, DecimalType):
+        if not isinstance(other, Decimal):
             return False
 
         return (self.precision == other.precision and
@@ -132,7 +180,7 @@ class DecimalType(DataType):
         return constructor
 
 
-class CategoryType(DataType):
+class Category(DataType):
 
     def __init__(self, cardinality=None):
         self.cardinality = cardinality
@@ -149,7 +197,7 @@ class CategoryType(DataType):
         return hash((self.cardinality))
 
     def __eq__(self, other):
-        if not isinstance(other, CategoryType):
+        if not isinstance(other, Category):
             return False
 
         return self.cardinality == other.cardinality
@@ -178,6 +226,24 @@ class CategoryType(DataType):
             return CategoryScalar(op, self, name=name)
         return constructor
 
+
+class Struct(DataType):
+    pass
+
+
+class Array(DataType):
+    pass
+
+
+class Enum(DataType):
+    pass
+
+
+class Map(DataType):
+
+    pass
+
+
 # ---------------------------------------------------------------------
 
 _primitive_types = set(['boolean', 'int8', 'int16', 'int32', 'int64',
@@ -205,11 +271,11 @@ def _parse_decimal(t):
     m = _DECIMAL_RE.match(t)
     if m:
         precision, scale = m.groups()
-        return DecimalType(int(precision), int(scale))
+        return Decimal(int(precision), int(scale))
 
     if t == 'decimal':
         # From the Impala documentation
-        return DecimalType(9, 0)
+        return Decimal(9, 0)
 
 
 _type_parsers = [

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -1,0 +1,225 @@
+# Copyright 2014 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import six
+
+import ibis.common as com
+import ibis.util as util
+
+if six.PY3:
+    from io import StringIO
+else:
+    from io import BytesIO as StringIO
+
+
+class Schema(object):
+
+    """
+    Holds table schema information
+    """
+
+    def __init__(self, names, types):
+        if not isinstance(names, list):
+            names = list(names)
+        self.names = names
+        self.types = [validate_type(x) for x in types]
+
+        self._name_locs = dict((v, i) for i, v in enumerate(self.names))
+
+        if len(self._name_locs) < len(self.names):
+            raise com.IntegrityError('Duplicate column names')
+
+    def __repr__(self):
+        return self._repr()
+
+    def __len__(self):
+        return len(self.names)
+
+    def _repr(self):
+        buf = StringIO()
+        space = 2 + max(len(x) for x in self.names)
+        for name, tipo in zip(self.names, self.types):
+            buf.write('\n{0}{1}'.format(name.ljust(space), str(tipo)))
+
+        return "ibis.Schema {{{0}\n}}".format(util.indent(buf.getvalue(), 2))
+
+    def __contains__(self, name):
+        return name in self._name_locs
+
+    @classmethod
+    def from_tuples(cls, values):
+        if len(values):
+            names, types = zip(*values)
+        else:
+            names, types = [], []
+        return Schema(names, types)
+
+    @classmethod
+    def from_dict(cls, values):
+        names = list(values.keys())
+        types = values.values()
+        return Schema(names, types)
+
+    def equals(self, other):
+        return ((self.names == other.names) and
+                (self.types == other.types))
+
+    def __eq__(self, other):
+        return self.equals(other)
+
+    def get_type(self, name):
+        return self.types[self._name_locs[name]]
+
+    def append(self, schema):
+        names = self.names + schema.names
+        types = self.types + schema.types
+        return Schema(names, types)
+
+
+class DataType(object):
+    pass
+
+
+class DecimalType(DataType):
+    # Decimal types are parametric, we store the parameters in this object
+
+    def __init__(self, precision, scale):
+        self.precision = precision
+        self.scale = scale
+
+    def _base_type(self):
+        return 'decimal'
+
+    def __repr__(self):
+        return ('decimal(precision=%s, scale=%s)'
+                % (self.precision, self.scale))
+
+    def __hash__(self):
+        return hash((self.precision, self.scale))
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __eq__(self, other):
+        if not isinstance(other, DecimalType):
+            return False
+
+        return (self.precision == other.precision and
+                self.scale == other.scale)
+
+    def array_ctor(self):
+        def constructor(op, name=None):
+            from ibis.expr.types import DecimalArray
+            return DecimalArray(op, self, name=name)
+        return constructor
+
+    def scalar_ctor(self):
+        def constructor(op, name=None):
+            from ibis.expr.types import DecimalScalar
+            return DecimalScalar(op, self, name=name)
+        return constructor
+
+
+class CategoryType(DataType):
+
+    def __init__(self, cardinality=None):
+        self.cardinality = cardinality
+
+    def _base_type(self):
+        return 'category'
+
+    def __repr__(self):
+        card = (self.cardinality if self.cardinality is not None
+                else 'unknown')
+        return ('category(K=%s)' % card)
+
+    def __hash__(self):
+        return hash((self.cardinality))
+
+    def __eq__(self, other):
+        if not isinstance(other, CategoryType):
+            return False
+
+        return self.cardinality == other.cardinality
+
+    def to_integer_type(self):
+        if self.cardinality is None:
+            return 'int64'
+        elif self.cardinality < (2 ** 7 - 1):
+            return 'int8'
+        elif self.cardinality < (2 ** 15 - 1):
+            return 'int16'
+        elif self.cardinality < (2 ** 31 - 1):
+            return 'int32'
+        else:
+            return 'int64'
+
+    def array_ctor(self):
+        def constructor(op, name=None):
+            from ibis.expr.types import CategoryArray
+            return CategoryArray(op, self, name=name)
+        return constructor
+
+    def scalar_ctor(self):
+        def constructor(op, name=None):
+            from ibis.expr.types import CategoryScalar
+            return CategoryScalar(op, self, name=name)
+        return constructor
+
+# ---------------------------------------------------------------------
+
+_primitive_types = set(['boolean', 'int8', 'int16', 'int32', 'int64',
+                        'float', 'double', 'string', 'timestamp',
+                        'category'])
+
+
+def validate_type(t):
+    if isinstance(t, DataType):
+        return t
+
+    parsed_type = _parse_type(t)
+    if parsed_type is not None:
+        return parsed_type
+
+    if t not in _primitive_types:
+        raise ValueError('Invalid type: %s' % repr(t))
+    return t
+
+
+_DECIMAL_RE = re.compile('decimal\((\d+),[\s]*(\d+)\)')
+
+
+def _parse_decimal(t):
+    m = _DECIMAL_RE.match(t)
+    if m:
+        precision, scale = m.groups()
+        return DecimalType(int(precision), int(scale))
+
+    if t == 'decimal':
+        # From the Impala documentation
+        return DecimalType(9, 0)
+
+
+_type_parsers = [
+    _parse_decimal
+]
+
+
+def _parse_type(t):
+    for parse_fn in _type_parsers:
+        parsed = parse_fn(t)
+        if parsed is not None:
+            return parsed
+    return None

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -156,6 +156,9 @@ class DataType(object):
 
         return isinstance(other, type(self))
 
+    def can_implicit_cast(self, other):
+        return self.equals(other)
+
     def scalar_type(self):
         name = type(self).__name__
         return getattr(ir, '{0}Scalar'.format(name))
@@ -189,7 +192,7 @@ class Integer(Primitive):
 
     def can_implicit_cast(self, other):
         if isinstance(other, Integer):
-            return other._nbytes < self._nbytes
+            return other._nbytes <= self._nbytes
         return False
 
 

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import ibis.util as util
+
+import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
 
@@ -79,7 +81,7 @@ class ExprFormatter(object):
         if self.memoize:
             self._memoize_tables()
 
-        if isinstance(what, ir.HasSchema):
+        if isinstance(what, dt.HasSchema):
             # This should also catch aggregations
             if not self.memoize and what in self.memo:
                 text = 'Table: %s' % self.memo.get_alias(what)
@@ -135,7 +137,7 @@ class ExprFormatter(object):
                 visit(op.args)
                 if isinstance(op, table_memo_ops):
                     self.memo.observe(op, self._format_node)
-            elif isinstance(op, ir.HasSchema):
+            elif isinstance(op, dt.HasSchema):
                 self.memo.observe(op, self._format_table)
 
         walk(self.expr)

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -15,6 +15,7 @@
 import operator
 
 from ibis.compat import py_string
+from ibis.expr.datatypes import DecimalType
 from ibis.expr.rules import value, string, number, integer, boolean, list_of
 from ibis.expr.types import (Node, as_value_expr,
                              ValueExpr, ArrayExpr, TableExpr,
@@ -647,7 +648,7 @@ def _sum_output_type(self):
     elif isinstance(arg, ir.FloatingValue):
         t = 'double'
     elif isinstance(arg, ir.DecimalValue):
-        t = ir.DecimalType(arg._precision, 38)
+        t = DecimalType(arg._precision, 38)
     else:
         raise TypeError(arg)
     return t
@@ -656,7 +657,7 @@ def _sum_output_type(self):
 def _mean_output_type(self):
     arg = self.args[0]
     if isinstance(arg, ir.DecimalValue):
-        t = ir.DecimalType(arg._precision, 38)
+        t = DecimalType(arg._precision, 38)
     elif isinstance(arg, ir.NumericValue):
         t = 'double'
     else:
@@ -689,7 +690,7 @@ class Mean(Reduction):
 
 
 def _decimal_scalar_ctor(precision, scale):
-    out_type = ir.DecimalType(precision, scale)
+    out_type = DecimalType(precision, scale)
     return ir.DecimalScalar._make_constructor(out_type)
 
 
@@ -700,7 +701,7 @@ class StdDeviation(Reduction):
 def _min_max_output_rule(self):
     arg = self.args[0]
     if isinstance(arg, ir.DecimalValue):
-        t = ir.DecimalType(arg._precision, 38)
+        t = DecimalType(arg._precision, 38)
     else:
         t = arg.type()
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -15,13 +15,13 @@
 import operator
 
 from ibis.compat import py_string
-from ibis.expr.datatypes import DecimalType
 from ibis.expr.rules import value, string, number, integer, boolean, list_of
 from ibis.expr.types import (Node, as_value_expr,
                              ValueExpr, ArrayExpr, TableExpr,
                              TableNode, ValueNode,
                              HasSchema, _safe_repr)
 import ibis.common as com
+import ibis.expr.datatypes as dt
 import ibis.expr.rules as rules
 import ibis.expr.types as ir
 import ibis.util as util
@@ -648,7 +648,7 @@ def _sum_output_type(self):
     elif isinstance(arg, ir.FloatingValue):
         t = 'double'
     elif isinstance(arg, ir.DecimalValue):
-        t = DecimalType(arg._precision, 38)
+        t = dt.Decimal(arg._precision, 38)
     else:
         raise TypeError(arg)
     return t
@@ -657,7 +657,7 @@ def _sum_output_type(self):
 def _mean_output_type(self):
     arg = self.args[0]
     if isinstance(arg, ir.DecimalValue):
-        t = DecimalType(arg._precision, 38)
+        t = dt.Decimal(arg._precision, 38)
     elif isinstance(arg, ir.NumericValue):
         t = 'double'
     else:
@@ -690,7 +690,7 @@ class Mean(Reduction):
 
 
 def _decimal_scalar_ctor(precision, scale):
-    out_type = DecimalType(precision, scale)
+    out_type = dt.Decimal(precision, scale)
     return ir.DecimalScalar._make_constructor(out_type)
 
 
@@ -701,7 +701,7 @@ class StdDeviation(Reduction):
 def _min_max_output_rule(self):
     arg = self.args[0]
     if isinstance(arg, ir.DecimalValue):
-        t = DecimalType(arg._precision, 38)
+        t = dt.Decimal(arg._precision, 38)
     else:
         t = arg.type()
 

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -17,7 +17,7 @@ import operator
 
 from ibis.common import IbisTypeError
 from ibis.compat import py_string
-from ibis.expr.datatypes import validate_type, DecimalType
+import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 import ibis.common as com
 import ibis.util as util
@@ -82,7 +82,7 @@ def _decimal_promoted_type(args):
         if isinstance(arg, ir.DecimalValue):
             precisions.append(arg.meta.precision)
             scales.append(arg.meta.scale)
-    return DecimalType(max(precisions), max(scales))
+    return dt.Decimal(max(precisions), max(scales))
 
 
 class PowerPromoter(BinaryPromoter):
@@ -696,7 +696,7 @@ class DataType(Argument):
         if isinstance(arg, py_string):
             arg = arg.lower()
 
-        arg = args[i] = validate_type(arg)
+        arg = args[i] = dt.validate_type(arg)
         return arg
 
 

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -17,6 +17,7 @@ import operator
 
 from ibis.common import IbisTypeError
 from ibis.compat import py_string
+from ibis.expr.datatypes import validate_type, DecimalType
 import ibis.expr.types as ir
 import ibis.common as com
 import ibis.util as util
@@ -81,7 +82,7 @@ def _decimal_promoted_type(args):
         if isinstance(arg, ir.DecimalValue):
             precisions.append(arg.meta.precision)
             scales.append(arg.meta.scale)
-    return ir.DecimalType(max(precisions), max(scales))
+    return DecimalType(max(precisions), max(scales))
 
 
 class PowerPromoter(BinaryPromoter):
@@ -695,7 +696,7 @@ class DataType(Argument):
         if isinstance(arg, py_string):
             arg = arg.lower()
 
-        arg = args[i] = ir._validate_type(arg)
+        arg = args[i] = validate_type(arg)
         return arg
 
 

--- a/ibis/expr/tests/mocks.py
+++ b/ibis/expr/tests/mocks.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from ibis.client import SQLClient
+from ibis.expr.datatypes import Schema
 import ibis.expr.types as ir
 import ibis
 
@@ -127,7 +128,7 @@ class MockConnection(SQLClient):
 
     def _get_table_schema(self, name):
         name = name.replace('`', '')
-        return ir.Schema.from_tuples(self._tables[name])
+        return Schema.from_tuples(self._tables[name])
 
     def execute(self, expr, limit=None):
         ast = self._build_ast_ensure_limit(expr, limit)

--- a/ibis/expr/tests/test_table.py
+++ b/ibis/expr/tests/test_table.py
@@ -14,6 +14,7 @@
 
 from ibis.expr.types import ArrayExpr, TableExpr, RelationError
 from ibis.common import ExpressionError
+from ibis.expr.datatypes import array_type
 import ibis.expr.analysis as L
 import ibis.expr.api as api
 import ibis.expr.types as ir
@@ -65,7 +66,7 @@ class TestTableExprBasics(BasicTestCase, unittest.TestCase):
 
             # Make sure it's the right type
             assert isinstance(col, ArrayExpr)
-            assert isinstance(col, ir.array_type(v))
+            assert isinstance(col, array_type(v))
 
             # Ensure we have a field selection with back-reference to the table
             parent = col.parent()

--- a/ibis/expr/tests/test_value_exprs.py
+++ b/ibis/expr/tests/test_value_exprs.py
@@ -17,6 +17,7 @@ import operator
 
 from ibis.common import IbisTypeError
 import ibis.expr.api as api
+import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
 import ibis
@@ -90,7 +91,7 @@ class TestLiterals(BasicTestCase, unittest.TestCase):
 
         for value, ex_type in cases:
             expr = ibis.literal(value)
-            klass = ir.scalar_type(ex_type)
+            klass = dt.scalar_type(ex_type)
             assert isinstance(expr, klass)
             assert isinstance(expr.op(), ir.Literal)
             assert expr.op().value is value
@@ -332,10 +333,10 @@ class TestTypeCasting(BasicTestCase, unittest.TestCase):
         for t in types:
             c = 'g'
             casted = self.table[c].cast(t)
-            assert isinstance(casted, ir.array_type(t))
+            assert isinstance(casted, dt.array_type(t))
 
             casted_literal = ibis.literal('5').cast(t).name('bar')
-            assert isinstance(casted_literal, ir.scalar_type(t))
+            assert isinstance(casted_literal, dt.scalar_type(t))
             assert casted_literal.get_name() == 'bar'
 
     def test_number_to_string(self):
@@ -606,11 +607,11 @@ class TestBinaryArithOps(BasicTestCase, unittest.TestCase):
             col = self.table[name]
 
             result = op(col, val)
-            ex_class = ir.array_type(ex_type)
+            ex_class = dt.array_type(ex_type)
             assert isinstance(result, ex_class)
 
             result = op(val, col)
-            ex_class = ir.array_type(ex_type)
+            ex_class = dt.array_type(ex_type)
             assert isinstance(result, ex_class)
 
     def test_add_array_promotions(self):

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -12,20 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
-
 import datetime
-import re
 
 from ibis.common import IbisError, RelationError
+from ibis.expr.datatypes import Schema, DataType, DecimalType
 import ibis.common as com
 import ibis.config as config
 import ibis.util as util
-
-if six.PY3:
-    from io import StringIO
-else:
-    from io import BytesIO as StringIO
 
 
 def _ops():
@@ -43,75 +36,6 @@ class Parameter(object):
 
 
 # ---------------------------------------------------------------------
-
-
-class Schema(object):
-
-    """
-    Holds table schema information
-    """
-
-    def __init__(self, names, types):
-        from ibis.expr.types import _validate_type
-        if not isinstance(names, list):
-            names = list(names)
-        self.names = names
-        self.types = [_validate_type(x) for x in types]
-
-        self._name_locs = dict((v, i) for i, v in enumerate(self.names))
-
-        if len(self._name_locs) < len(self.names):
-            raise com.IntegrityError('Duplicate column names')
-
-    def __repr__(self):
-        return self._repr()
-
-    def __len__(self):
-        return len(self.names)
-
-    def _repr(self):
-        buf = StringIO()
-        space = 2 + max(len(x) for x in self.names)
-        for name, tipo in zip(self.names, self.types):
-            buf.write('\n{0}{1}'.format(name.ljust(space), str(tipo)))
-
-        return "ibis.Schema {{{0}\n}}".format(util.indent(buf.getvalue(), 2))
-
-    def __contains__(self, name):
-        return name in self._name_locs
-
-    @classmethod
-    def from_tuples(cls, values):
-        if len(values):
-            names, types = zip(*values)
-        else:
-            names, types = [], []
-        return Schema(names, types)
-
-    @classmethod
-    def from_dict(cls, values):
-        names = list(values.keys())
-        types = values.values()
-        return Schema(names, types)
-
-    def equals(self, other):
-        return ((self.names == other.names) and
-                (self.types == other.types))
-
-    def __eq__(self, other):
-        return self.equals(other)
-
-    def get_type(self, name):
-        return self.types[self._name_locs[name]]
-
-    def append(self, schema):
-        names = self.names + schema.names
-        types = self.types + schema.types
-        return Schema(names, types)
-
-
-class DataType(object):
-    pass
 
 
 class HasSchema(object):
@@ -982,44 +906,6 @@ class StringValue(AnyValue):
         return isinstance(other, StringValue)
 
 
-class DecimalType(DataType):
-    # Decimal types are parametric, we store the parameters in this object
-
-    def __init__(self, precision, scale):
-        self.precision = precision
-        self.scale = scale
-
-    def _base_type(self):
-        return 'decimal'
-
-    def __repr__(self):
-        return ('decimal(precision=%s, scale=%s)'
-                % (self.precision, self.scale))
-
-    def __hash__(self):
-        return hash((self.precision, self.scale))
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    def __eq__(self, other):
-        if not isinstance(other, DecimalType):
-            return False
-
-        return (self.precision == other.precision and
-                self.scale == other.scale)
-
-    def array_ctor(self):
-        def constructor(op, name=None):
-            return DecimalArray(op, self, name=name)
-        return constructor
-
-    def scalar_ctor(self):
-        def constructor(op, name=None):
-            return DecimalScalar(op, self, name=name)
-        return constructor
-
-
 class DecimalValue(NumericValue):
 
     _typename = 'decimal'
@@ -1176,51 +1062,6 @@ class DecimalArray(DecimalValue, NumericArray):
         return factory
 
 
-class CategoryType(DataType):
-
-    def __init__(self, cardinality=None):
-        self.cardinality = cardinality
-
-    def _base_type(self):
-        return 'category'
-
-    def __repr__(self):
-        card = (self.cardinality if self.cardinality is not None
-                else 'unknown')
-        return ('category(K=%s)' % card)
-
-    def __hash__(self):
-        return hash((self.cardinality))
-
-    def __eq__(self, other):
-        if not isinstance(other, CategoryType):
-            return False
-
-        return self.cardinality == other.cardinality
-
-    def to_integer_type(self):
-        if self.cardinality is None:
-            return 'int64'
-        elif self.cardinality < (2 ** 7 - 1):
-            return 'int8'
-        elif self.cardinality < (2 ** 15 - 1):
-            return 'int16'
-        elif self.cardinality < (2 ** 31 - 1):
-            return 'int32'
-        else:
-            return 'int64'
-
-    def array_ctor(self):
-        def constructor(op, name=None):
-            return CategoryArray(op, self, name=name)
-        return constructor
-
-    def scalar_ctor(self):
-        def constructor(op, name=None):
-            return CategoryScalar(op, self, name=name)
-        return constructor
-
-
 class CategoryValue(AnyValue):
 
     """
@@ -1310,48 +1151,6 @@ _array_types = {
     'timestamp': TimestampArray,
     'category': CategoryArray
 }
-
-# ---------------------------------------------------------------------
-
-
-def _validate_type(t):
-    if isinstance(t, DataType):
-        return t
-
-    parsed_type = _parse_type(t)
-    if parsed_type is not None:
-        return parsed_type
-
-    if t not in _array_types:
-        raise ValueError('Invalid type: %s' % repr(t))
-    return t
-
-
-_DECIMAL_RE = re.compile('decimal\((\d+),[\s]*(\d+)\)')
-
-
-def _parse_decimal(t):
-    m = _DECIMAL_RE.match(t)
-    if m:
-        precision, scale = m.groups()
-        return DecimalType(int(precision), int(scale))
-
-    if t == 'decimal':
-        # From the Impala documentation
-        return DecimalType(9, 0)
-
-
-_type_parsers = [
-    _parse_decimal
-]
-
-
-def _parse_type(t):
-    for parse_fn in _type_parsers:
-        parsed = parse_fn(t)
-        if parsed is not None:
-            return parsed
-    return None
 
 
 class UnnamedMarker(object):

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -15,9 +15,10 @@
 import datetime
 
 from ibis.common import IbisError, RelationError
-from ibis.expr.datatypes import Schema, DataType, DecimalType
+from ibis.expr.datatypes import Schema, DataType
 import ibis.common as com
 import ibis.config as config
+import ibis.expr.datatypes as dt
 import ibis.util as util
 
 
@@ -917,7 +918,7 @@ class DecimalValue(NumericValue):
         self._scale = meta.scale
 
     def type(self):
-        return DecimalType(self._precision, self._scale)
+        return dt.Decimal(self._precision, self._scale)
 
     def _base_type(self):
         return 'decimal'

--- a/ibis/sql/ddl.py
+++ b/ibis/sql/ddl.py
@@ -17,6 +17,7 @@ import re
 
 from ibis.sql.exprs import (ExprTranslator, quote_identifier,
                             _sql_type_names, _type_to_sql_string)
+import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
 import ibis.common as com
@@ -901,9 +902,9 @@ class CreateFunction(DDLStatement):
     def compile(self):
         create_decl = 'CREATE FUNCTION'
         scoped_name = self._get_scoped_name()
-        create_line = '{0!s}({1!s}) returns {2!s}'.format(scoped_name,
-                                                          ', '.join(self.inputs),
-                                                          self.output)
+        create_line = ('{0!s}({1!s}) returns {2!s}'
+                       .format(scoped_name, ', '.join(self.inputs),
+                               self.output))
         param_line = "location '{0!s}' symbol='{1!s}'".format(self.hdfs_file,
                                                               self.so_symbol)
         full_line = ' '.join([create_decl, create_line, param_line])
@@ -938,9 +939,9 @@ class CreateAggregateFunction(DDLStatement):
     def compile(self):
         create_decl = 'CREATE AGGREGATE FUNCTION'
         scoped_name = self._get_scoped_name()
-        create_line = '{0!s}({1!s}) returns {2!s}'.format(scoped_name,
-                                                          ', '.join(self.inputs),
-                                                          self.output)
+        create_line = ('{0!s}({1!s}) returns {2!s}'
+                       .format(scoped_name, ', '.join(self.inputs),
+                               self.output))
         loc_ln = "location '{0!s}'".format(self.hdfs_file)
         init_ln = "init_fn='{0}'".format(self.init)
         update_ln = "update_fn='{0}'".format(self.update)
@@ -974,7 +975,7 @@ class DropFunction(DropObject):
     def _ibis_string_to_impala(self, tval):
         if tval in _sql_type_names.keys():
             return _sql_type_names[tval]
-        result = ir._parse_decimal(tval)
+        result = dt._parse_decimal(tval)
         if result:
             return 'decimal({0},{1})'.format(result.precision,
                                              result.scale)

--- a/ibis/sql/ddl.py
+++ b/ibis/sql/ddl.py
@@ -871,7 +871,7 @@ def _format_schema_element(name, t):
 
 
 def _format_type(t):
-    if isinstance(t, ir.DecimalType):
+    if isinstance(t, dt.Decimal):
         return 'DECIMAL({0},{1})'.format(t.precision, t.scale)
     else:
         return _impala_type_names[t]

--- a/ibis/sql/exprs.py
+++ b/ibis/sql/exprs.py
@@ -62,7 +62,7 @@ def _type_to_sql_string(tval):
     if isinstance(tval, dt.Decimal):
         return 'decimal({0},{1})'.format(tval.precision, tval.scale)
     else:
-        return _sql_type_names[tval]
+        return _sql_type_names[tval.name()]
 
 
 def _between(translator, expr):

--- a/ibis/sql/exprs.py
+++ b/ibis/sql/exprs.py
@@ -18,6 +18,7 @@ from io import BytesIO
 import ibis
 import ibis.expr.analysis as L
 import ibis.expr.analytics as analytics
+import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
 import ibis.expr.temporal as tempo
@@ -58,7 +59,7 @@ def _cast(translator, expr):
 
 
 def _type_to_sql_string(tval):
-    if isinstance(tval, ir.DecimalType):
+    if isinstance(tval, dt.Decimal):
         return 'decimal({0},{1})'.format(tval.precision, tval.scale)
     else:
         return _sql_type_names[tval]

--- a/ibis/sql/tests/test_compiler.py
+++ b/ibis/sql/tests/test_compiler.py
@@ -1678,9 +1678,9 @@ FROM test1""".format(path)
 
         expected = """\
 CREATE TABLE foo.`another_table`
-(`foo` STRING,
- `bar` TINYINT,
- `baz` SMALLINT)
+(`foo` string,
+ `bar` tinyint,
+ `baz` smallint)
 LOCATION '{0}'""".format(path)
         assert result == expected
 
@@ -1739,9 +1739,9 @@ LOCATION '{1}'""".format(example_table, directory)
         result = statement.compile()
         expected = """\
 CREATE EXTERNAL TABLE IF NOT EXISTS foo.`new_table`
-(`foo` STRING,
- `bar` TINYINT,
- `baz` SMALLINT)
+(`foo` string,
+ `bar` tinyint,
+ `baz` smallint)
 STORED AS PARQUET
 LOCATION '{0}'""".format(directory)
 
@@ -1764,10 +1764,10 @@ LOCATION '{0}'""".format(directory)
         result = stmt.compile()
         expected = """\
 CREATE EXTERNAL TABLE IF NOT EXISTS foo.`new_table`
-(`a` STRING,
- `b` INT,
- `c` DOUBLE,
- `d` DECIMAL(12,2))
+(`a` string,
+ `b` int,
+ `c` double,
+ `d` decimal(12,2))
 ROW FORMAT DELIMITED
 FIELDS TERMINATED BY '|'
 ESCAPED BY '\\'

--- a/ibis/sql/udf.py
+++ b/ibis/sql/udf.py
@@ -22,7 +22,8 @@ from ibis.expr.types import (
 )
 from ibis.common import IbisTypeError
 
-import ibis.expr.types as ir
+from ibis.expr.datatypes import validate_type
+import ibis.expr.datatypes as _dt
 import ibis.expr.operations as _ops
 import ibis.expr.rules as rules
 import ibis.sql.exprs as _expr
@@ -51,8 +52,8 @@ class UDFCreatorParent(UDFInfo):
         if not(file_suffix == '.so' or file_suffix == '.ll'):
             raise ValueError('Invalid file type. Must be .so or .ll ')
         self.hdfs_file = hdfs_file
-        inputs = [ir._validate_type(x) for x in input_type]
-        output = ir._validate_type(output_type)
+        inputs = [validate_type(x) for x in input_type]
+        output = validate_type(output_type)
         new_name = name
         if not name:
             string = self.so_symbol
@@ -117,15 +118,15 @@ class UDACreator(UDFCreatorParent):
 def _validate_impala_type(t):
     if t in _impala_to_ibis.keys():
         return t
-    elif ir._DECIMAL_RE.match(t):
+    elif _dt._DECIMAL_RE.match(t):
         return t
     raise IbisTypeError("Not a valid Impala type for UDFs")
 
 
 def _operation_type_conversion(inputs, output):
-    in_type = [ir._validate_type(x) for x in inputs]
+    in_type = [validate_type(x) for x in inputs]
     in_values = [rules.value_typed_as(_convert_types(x)) for x in in_type]
-    out_type = ir._validate_type(output)
+    out_type = validate_type(output)
     out_value = rules.shape_like_flatargs(out_type)
     return (in_values, out_value)
 
@@ -153,7 +154,7 @@ def add_impala_operation(op, func_name, db):
 def _impala_type_to_ibis(tval):
     if tval in _impala_to_ibis.keys():
         return _impala_to_ibis[tval]
-    result = ir._parse_decimal(tval)
+    result = _dt._parse_decimal(tval)
     if result:
         return result.__repr__()
     raise Exception('Not a valid Impala type')
@@ -162,7 +163,7 @@ def _impala_type_to_ibis(tval):
 def _ibis_string_to_impala(tval):
     if tval in _expr._sql_type_names.keys():
         return _expr._sql_type_names[tval]
-    result = ir._parse_decimal(tval)
+    result = _dt._parse_decimal(tval)
     if result:
         return result.__repr__()
 

--- a/ibis/tests/test_impala_e2e.py
+++ b/ibis/tests/test_impala_e2e.py
@@ -23,7 +23,7 @@ from decimal import Decimal
 import ibis
 
 from ibis.compat import unittest
-from ibis.expr.datatypes import CategoryType
+from ibis.expr.datatypes import Category
 from ibis.sql.compiler import to_sql
 from ibis.tests.util import IbisTestEnv, ImpalaE2E, assert_equal, connect_test
 
@@ -517,7 +517,7 @@ LIMIT 10"""
         t = self.con.sql(query)
 
         def _clean_type(x):
-            if isinstance(x, CategoryType):
+            if isinstance(x, Category):
                 x = x.to_integer_type()
             return x
 

--- a/ibis/tests/test_pandas_interop.py
+++ b/ibis/tests/test_pandas_interop.py
@@ -17,9 +17,10 @@ import pandas as pd
 import pytest
 
 import ibis
+import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis.compat import unittest
-from ibis.util import pandas_to_ibis_schema
+from ibis.client import pandas_to_ibis_schema
 from ibis.common import IbisTypeError
 from ibis.tests.util import ImpalaE2E
 
@@ -161,7 +162,7 @@ class TestPandasSchemaInference(unittest.TestCase):
     def test_dtype_categorical(self):
         df = pd.DataFrame({'col': ['a', 'b', 'c', 'a']}, dtype='category')
         inferred = pandas_to_ibis_schema(df)
-        expected = ibis.schema([('col', 'category')])
+        expected = ibis.schema([('col', dt.Category(3))])
         assert inferred == expected
 
 

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -14,13 +14,6 @@
 
 import types
 
-import numpy as np
-import pandas as pd
-import pandas.core.common as pdcom
-
-import ibis
-from ibis.common import IbisTypeError
-
 
 def guid():
     try:
@@ -123,65 +116,6 @@ class IbisMap(object):
             if key.equals(k):
                 return v
         raise KeyError(key)
-
-
-def pandas_col_to_ibis_type(col):
-    dty = col.dtype
-
-    # datetime types
-    if pdcom.is_datetime64_dtype(dty):
-        if pdcom.is_datetime64_ns_dtype(dty):
-            return 'timestamp'
-        else:
-            raise IbisTypeError(
-                "Column {0} has dtype {1}, which is datetime64-like but does "
-                "not use nanosecond units".format(col.name, dty))
-    if pdcom.is_timedelta64_dtype(dty):
-        print("Warning: encoding a timedelta64 as an int64")
-        return 'int64'
-
-    if pdcom.is_categorical_dtype(dty):
-        return 'category'
-
-    if pdcom.is_bool_dtype(dty):
-        return 'boolean'
-
-    # simple numerical types
-    if issubclass(dty.type, np.int8):
-        return 'int8'
-    if issubclass(dty.type, np.int16):
-        return 'int16'
-    if issubclass(dty.type, np.int32):
-        return 'int32'
-    if issubclass(dty.type, np.int64):
-        return 'int64'
-    if issubclass(dty.type, np.float32):
-        return 'float'
-    if issubclass(dty.type, np.float64):
-        return 'double'
-    if issubclass(dty.type, np.uint8):
-        return 'int16'
-    if issubclass(dty.type, np.uint16):
-        return 'int32'
-    if issubclass(dty.type, np.uint32):
-        return 'int64'
-    if issubclass(dty.type, np.uint64):
-        raise IbisTypeError("Column {0} is an unsigned int64".format(col.name))
-
-    if pdcom.is_object_dtype(dty):
-        # TODO: overly broad?
-        return 'string'
-
-    raise IbisTypeError("Column {0} is dtype {1}".format(col.name, dty))
-
-
-def pandas_to_ibis_schema(frame):
-    # no analog for decimal in pandas
-    pairs = []
-    for col_name in frame:
-        ibis_type = pandas_col_to_ibis_type(frame[col_name])
-        pairs.append((col_name, ibis_type))
-    return ibis.schema(pairs)
 
 
 def is_function(v):


### PR DESCRIPTION
This makes all data types, including primitives, proper objects, e.g. `Int16` or `String`. This will make it easier to create more complex schemas and deal with implicit casts and other items on the roadmap. 

Close #235. 