### PR TITLE
ENH: Add SQLite built-in function coverage

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1418,6 +1418,28 @@ def regex_replace(arg, pattern, replacement):
     return _ops.RegexReplace(arg, pattern, replacement).to_expr()
 
 
+def _string_replace(arg, pattern, replacement):
+    """
+    Replaces each exactly occurrence of pattern with given replacement
+    string. Like Python built-in str.replace
+
+    Parameters
+    ----------
+    pattern : string
+    replacement : string
+
+    Examples
+    --------
+    table.strings.replace('aaa', 'foo')
+    'aaabbbaaa' becomes 'foobbbfoo'
+
+    Returns
+    -------
+    replaced : string
+    """
+    return _ops.StringReplace(arg, pattern, replacement).to_expr()
+
+
 def parse_url(arg, extract, key=None):
     """
     Returns the portion of a URL corresponding to a part specified
@@ -1479,6 +1501,7 @@ _string_value_methods = dict(
     contains=_string_contains,
     like=_string_like,
     rlike=re_search,
+    replace=_string_replace,
     re_search=re_search,
     re_extract=regex_extract,
     re_replace=regex_replace,

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1549,7 +1549,25 @@ def _timestamp_truncate(arg, unit):
     return _ops.Truncate(arg, unit).to_expr()
 
 
+def _timestamp_strftime(arg, format_str):
+    """
+    Format timestamp according to the passed format string. Format string may
+    depend on backend, but we try to conform to ANSI strftime (e.g. Python
+    built-in datetime.strftime)
+
+    Parameters
+    ----------
+    format_str : string
+
+    Returns
+    -------
+    formatted : string
+    """
+    return _ops.Strftime(arg, format_str).to_expr()
+
+
 _timestamp_value_methods = dict(
+    strftime=_timestamp_strftime,
     year=_extract_field('year', _ops.ExtractYear),
     month=_extract_field('month', _ops.ExtractMonth),
     day=_extract_field('day', _ops.ExtractDay),

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -413,6 +413,17 @@ cast_expr : ValueExpr
 """.format(_data_type_docs)
 
 
+def typeof(arg):
+    """
+    Return the data type of the argument according to the current backend
+
+    Returns
+    -------
+    typeof_arg : string
+    """
+    return _ops.TypeOf(arg).to_expr()
+
+
 def hash(arg, how='fnv'):
     """
     Compute an integer hash value for the indicated value expression.
@@ -653,6 +664,7 @@ rdiv = _rbinop_expr('__rdiv__', _ops.Divide)
 _generic_value_methods = dict(
     hash=hash,
     cast=cast,
+    typeof=typeof,
     fillna=fillna,
     nullif=nullif,
     between=between,

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2086,6 +2086,12 @@ class Truncate(ValueOp):
     output_type = rules.shape_like_arg(0, 'timestamp')
 
 
+class Strftime(ValueOp):
+
+    input_type = [rules.timestamp, rules.string(name='format_str')]
+    output_type = rules.shape_like_arg(0, 'string')
+
+
 class ExtractTimestampField(TimestampUnaryOp):
 
     output_type = rules.shape_like_arg(0, 'int32')

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -515,8 +515,13 @@ class RegexExtract(ValueOp):
 
 class RegexReplace(ValueOp):
 
-    input_type = [string, string(name='pattern'),
-                  string(name='replacement')]
+    input_type = [string, string(name='pattern'), string(name='replacement')]
+    output_type = rules.shape_like_arg(0, 'string')
+
+
+class StringReplace(ValueOp):
+
+    input_type = [string, string(name='pattern'), string(name='replacement')]
     output_type = rules.shape_like_arg(0, 'string')
 
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -148,6 +148,13 @@ class Cast(ValueOp):
         return rules.shape_like(self.args[0], self.args[1])
 
 
+class TypeOf(ValueOp):
+
+    input_type = [value]
+    output_type = rules.shape_like_arg(0, 'string')
+
+
+
 class Negate(UnaryOp):
 
     input_type = [number]

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -1058,7 +1058,7 @@ def _from_unixtime(translator, expr):
     return 'from_unixtime({0}, "yyyy-MM-dd HH:mm:ss")'.format(arg)
 
 
-def _varargs(func_name):
+def varargs(func_name):
     def varargs_formatter(translator, expr):
         op = expr.op()
         return _format_call(translator, func_name, *op.args)
@@ -1354,9 +1354,9 @@ _operation_registry = {
 
     ops.Cast: _cast,
 
-    ops.Coalesce: _varargs('coalesce'),
-    ops.Greatest: _varargs('greatest'),
-    ops.Least: _varargs('least'),
+    ops.Coalesce: varargs('coalesce'),
+    ops.Greatest: varargs('greatest'),
+    ops.Least: varargs('least'),
 
     ops.Where: _fixed_arity_call('if', 3),
 

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -1069,7 +1069,6 @@ def _substring(translator, expr):
     op = expr.op()
     arg, start, length = op.args
     arg_formatted = translator.translate(arg)
-
     start_formatted = translator.translate(start)
 
     # Impala is 1-indexed

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -291,7 +291,9 @@ _operation_registry = {
 
     ops.IsNull: _is_null,
     ops.NotNull: _not_null,
-    ops.Negate: fixed_arity(sa.not_, 1),
+    ops.Negate: unary(sa.not_),
+
+    ops.TypeOf: unary(sa.func.typeof),
 
     ir.Literal: _literal,
     ir.ValueList: _value_list,

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -275,6 +275,8 @@ _operation_registry = {
 
     ops.Coalesce: varargs(sa.func.coalesce),
 
+    ops.NullIf: fixed_arity(sa.func.nullif, 2),
+
     ops.Contains: _contains,
 
     ops.Count: _reduction(sa.func.count),

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -235,6 +235,20 @@ def _not_null(t, expr):
     return arg.isnot(sa.null())
 
 
+def _round(t, expr):
+    op = expr.op()
+    arg, digits = op.args
+    sa_arg = t.translate(arg)
+
+    f = sa.func.round
+
+    if digits is not None:
+        sa_digits = t.translate(digits)
+        return f(sa_arg, sa_digits)
+    else:
+        return f(sa_arg)
+
+
 def _simple_case(t, expr):
     op = expr.op()
 
@@ -292,6 +306,8 @@ _operation_registry = {
     ops.IsNull: _is_null,
     ops.NotNull: _not_null,
     ops.Negate: unary(sa.not_),
+
+    ops.Round: _round,
 
     ops.TypeOf: unary(sa.func.typeof),
 

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -259,6 +259,8 @@ _operation_registry = {
 
     ops.GroupConcat: _fixed_arity_call(sa.func.group_concat, 2),
 
+    ops.Negate: _fixed_arity_call(sa.not_, 1),
+
     ir.Literal: _literal,
     ir.ValueList: _value_list,
     ir.NullLiteral: lambda *args: sa.null(),

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import operator
+import six
 
 import sqlalchemy as sa
 import sqlalchemy.sql as sql
@@ -99,6 +100,9 @@ def table_from_schema(name, meta, schema):
 
 
 def _fixed_arity_call(sa_func, arity):
+    if isinstance(sa_func, six.string_types):
+        sa_func = getattr(sa.func, sa_func)
+
     def formatter(translator, expr):
         if arity != len(expr.op().args):
             raise com.IbisError('incorrect number of args')

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -387,8 +387,9 @@ class AlchemyQueryBuilder(comp.QueryBuilder):
     def _make_context(self):
         return AlchemyContext(dialect=self.dialect)
 
-    def _make_union(self):
-        raise NotImplementedError
+    @property
+    def _union_class(self):
+        return AlchemyUnion
 
 
 def to_sqlalchemy(expr, context=None, exists=False, dialect=None):
@@ -709,15 +710,14 @@ class AlchemyUnion(Union):
         context = self.context
 
         if self.distinct:
-            union_keyword = 'UNION'
+            sa_func = sa.union
         else:
-            union_keyword = 'UNION ALL'
+            sa_func = sa.union_all
 
         left_set = context.get_compiled_expr(self.left)
         right_set = context.get_compiled_expr(self.right)
 
-        query = '{0}\n{1}\n{2}'.format(left_set, union_keyword, right_set)
-        return query
+        return sa_func(left_set, right_set)
 
 
 class AlchemyProxy(object):

--- a/ibis/sql/sqlite/compiler.py
+++ b/ibis/sql/sqlite/compiler.py
@@ -113,6 +113,10 @@ def _strftime_int(fmt):
     return translator
 
 
+def _now(t, expr):
+    return sa.func.datetime('now')
+
+
 def _millisecond(t, expr):
     arg, = expr.op().args
     sa_arg = t.translate(arg)
@@ -153,6 +157,7 @@ _operation_registry.update({
     ops.ExtractMinute: _strftime_int('%M'),
     ops.ExtractSecond: _strftime_int('%S'),
     ops.ExtractMillisecond: _millisecond,
+    ops.TimestampNow: _now
 })
 
 

--- a/ibis/sql/sqlite/compiler.py
+++ b/ibis/sql/sqlite/compiler.py
@@ -16,8 +16,54 @@ import sqlalchemy as sa
 
 import ibis.sql.alchemy as alch
 import ibis.expr.datatypes as dt
+import ibis.expr.operations as ops
 
 _operation_registry = alch._operation_registry.copy()
+
+
+def _substr(translator, expr):
+    f = sa.func.substr
+
+    arg, start, length = expr.op().args
+
+    sa_arg = translator.translate(arg)
+    sa_start = translator.translate(start)
+
+    if length is None:
+        return f(sa_arg, sa_start + 1)
+    else:
+        sa_length = translator.translate(length)
+        return f(sa_arg, sa_start + 1, sa_length)
+
+
+def _string_right(translator, expr):
+    f = sa.func.substr
+
+    arg, length = expr.op().args
+
+    sa_arg = translator.translate(arg)
+    sa_length = translator.translate(length)
+
+    return f(sa_arg, -sa_length, sa_length)
+
+
+def _unary_op(sa_func):
+    return alch._fixed_arity_call(sa_func, 1)
+
+
+_operation_registry.update({
+    ops.Substring: _substr,
+    ops.StrRight: _string_right,
+
+    ops.StringLength: _unary_op('length'),
+
+    ops.Lowercase: _unary_op('lower'),
+    ops.Uppercase: _unary_op('upper'),
+
+    ops.Strip: _unary_op('trim'),
+    ops.LStrip: _unary_op('ltrim'),
+    ops.RStrip: _unary_op('rtrim'),
+})
 
 
 def add_operation(op, translation_func):

--- a/ibis/sql/sqlite/compiler.py
+++ b/ibis/sql/sqlite/compiler.py
@@ -113,6 +113,13 @@ def _strftime_int(fmt):
     return translator
 
 
+def _millisecond(t, expr):
+    arg, = expr.op().args
+    sa_arg = t.translate(arg)
+    fractional_second = sa.func.strftime('%f', sa_arg)
+    return (fractional_second * 1000) % 1000
+
+
 _operation_registry.update({
     ops.Cast: _cast,
 
@@ -145,6 +152,7 @@ _operation_registry.update({
     ops.ExtractHour: _strftime_int('%H'),
     ops.ExtractMinute: _strftime_int('%M'),
     ops.ExtractSecond: _strftime_int('%S'),
+    ops.ExtractMillisecond: _millisecond,
 })
 
 

--- a/ibis/sql/sqlite/compiler.py
+++ b/ibis/sql/sqlite/compiler.py
@@ -92,6 +92,7 @@ _operation_registry.update({
     ops.LStrip: unary('ltrim'),
     ops.RStrip: unary('rtrim'),
 
+    ops.StringReplace: fixed_arity(sa.func.replace, 3),
     ops.StringSQLLike: _infix_op('LIKE'),
     ops.RegexSearch: _infix_op('REGEXP'),
 })

--- a/ibis/sql/sqlite/compiler.py
+++ b/ibis/sql/sqlite/compiler.py
@@ -64,6 +64,18 @@ def _unary_op(sa_func):
     return alch._fixed_arity_call(sa_func, 1)
 
 
+def _infix_op(infix_sym):
+    def formatter(translator, expr):
+        op = expr.op()
+        left, right = op.args
+
+        left_arg = translator.translate(left)
+        right_arg = translator.translate(right)
+        return left_arg.op(infix_sym)(right_arg)
+
+    return formatter
+
+
 _operation_registry.update({
     ops.Substring: _substr,
     ops.StrRight: _string_right,
@@ -78,6 +90,8 @@ _operation_registry.update({
     ops.Strip: _unary_op('trim'),
     ops.LStrip: _unary_op('ltrim'),
     ops.RStrip: _unary_op('rtrim'),
+
+    ops.StringSQLLike: _infix_op('LIKE'),
 })
 
 

--- a/ibis/sql/sqlite/compiler.py
+++ b/ibis/sql/sqlite/compiler.py
@@ -14,7 +14,7 @@
 
 import sqlalchemy as sa
 
-from ibis.sql.alchemy import unary, varargs
+from ibis.sql.alchemy import unary, varargs, fixed_arity
 import ibis.sql.alchemy as alch
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
@@ -83,6 +83,7 @@ _operation_registry.update({
 
     ops.Least: varargs(sa.func.min),
     ops.Greatest: varargs(sa.func.max),
+    ops.IfNull: fixed_arity(sa.func.ifnull, 2),
 
     ops.Lowercase: unary('lower'),
     ops.Uppercase: unary('upper'),

--- a/ibis/sql/sqlite/compiler.py
+++ b/ibis/sql/sqlite/compiler.py
@@ -93,6 +93,7 @@ _operation_registry.update({
     ops.RStrip: unary('rtrim'),
 
     ops.StringSQLLike: _infix_op('LIKE'),
+    ops.RegexSearch: _infix_op('REGEXP'),
 })
 
 

--- a/ibis/sql/sqlite/compiler.py
+++ b/ibis/sql/sqlite/compiler.py
@@ -14,6 +14,7 @@
 
 import sqlalchemy as sa
 
+from ibis.sql.alchemy import unary, varargs
 import ibis.sql.alchemy as alch
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
@@ -60,10 +61,6 @@ def _string_find(translator, expr):
     return f(sa_arg, sa_substr) - 1
 
 
-def _unary_op(sa_func):
-    return alch._fixed_arity_call(sa_func, 1)
-
-
 def _infix_op(infix_sym):
     def formatter(translator, expr):
         op = expr.op()
@@ -82,14 +79,17 @@ _operation_registry.update({
 
     ops.StringFind: _string_find,
 
-    ops.StringLength: _unary_op('length'),
+    ops.StringLength: unary('length'),
 
-    ops.Lowercase: _unary_op('lower'),
-    ops.Uppercase: _unary_op('upper'),
+    ops.Least: varargs(sa.func.min),
+    ops.Greatest: varargs(sa.func.max),
 
-    ops.Strip: _unary_op('trim'),
-    ops.LStrip: _unary_op('ltrim'),
-    ops.RStrip: _unary_op('rtrim'),
+    ops.Lowercase: unary('lower'),
+    ops.Uppercase: unary('upper'),
+
+    ops.Strip: unary('trim'),
+    ops.LStrip: unary('ltrim'),
+    ops.RStrip: unary('rtrim'),
 
     ops.StringSQLLike: _infix_op('LIKE'),
 })

--- a/ibis/sql/sqlite/compiler.py
+++ b/ibis/sql/sqlite/compiler.py
@@ -47,6 +47,19 @@ def _string_right(translator, expr):
     return f(sa_arg, -sa_length, sa_length)
 
 
+def _string_find(translator, expr):
+    arg, substr, start, _ = expr.op().args
+
+    if start is not None:
+        raise NotImplementedError
+
+    sa_arg = translator.translate(arg)
+    sa_substr = translator.translate(substr)
+
+    f = sa.func.instr
+    return f(sa_arg, sa_substr) - 1
+
+
 def _unary_op(sa_func):
     return alch._fixed_arity_call(sa_func, 1)
 
@@ -54,6 +67,8 @@ def _unary_op(sa_func):
 _operation_registry.update({
     ops.Substring: _substr,
     ops.StrRight: _string_right,
+
+    ops.StringFind: _string_find,
 
     ops.StringLength: _unary_op('length'),
 

--- a/ibis/sql/sqlite/tests/common.py
+++ b/ibis/sql/sqlite/tests/common.py
@@ -46,6 +46,11 @@ class SQLiteTests(object):
     def _to_sqla(self, table):
         return table.op().sqla_table
 
+    def _check_e2e_cases(self, cases):
+        for expr, expected in cases:
+            result = self.db.execute(expr)
+            assert result == expected
+
 
 class SQLiteTestEnv(object):
 

--- a/ibis/sql/sqlite/tests/common.py
+++ b/ibis/sql/sqlite/tests/common.py
@@ -27,8 +27,8 @@ class SQLiteTests(object):
     def setUpClass(cls):
         cls.env = SQLiteTestEnv()
         cls.dialect = sqlite_dialect()
-        cls.db = api.connect(cls.env.db_path)
-        cls.alltypes = cls.db.table('functional_alltypes')
+        cls.con = api.connect(cls.env.db_path)
+        cls.alltypes = cls.con.table('functional_alltypes')
 
     def _check_expr_cases(self, cases, context=None, named=False):
         for expr, expected in cases:
@@ -48,7 +48,7 @@ class SQLiteTests(object):
 
     def _check_e2e_cases(self, cases):
         for expr, expected in cases:
-            result = self.db.execute(expr)
+            result = self.con.execute(expr)
             assert result == expected
 
 

--- a/ibis/sql/sqlite/tests/test_client.py
+++ b/ibis/sql/sqlite/tests/test_client.py
@@ -27,7 +27,7 @@ class TestSQLiteClient(SQLiteTests, unittest.TestCase):
         pass
 
     def test_table(self):
-        table = self.db.table('functional_alltypes')
+        table = self.con.table('functional_alltypes')
         assert isinstance(table, ir.TableExpr)
 
     def test_array_execute(self):
@@ -38,7 +38,7 @@ class TestSQLiteClient(SQLiteTests, unittest.TestCase):
 
     def test_literal_execute(self):
         expr = ibis.literal('1234')
-        result = self.db.execute(expr)
+        result = self.con.execute(expr)
         assert result == '1234'
 
     def test_simple_aggregate_execute(self):
@@ -47,5 +47,5 @@ class TestSQLiteClient(SQLiteTests, unittest.TestCase):
         assert isinstance(v, float)
 
     def test_list_tables(self):
-        assert len(self.db.list_tables()) > 0
-        assert len(self.db.list_tables(like='functional')) == 1
+        assert len(self.con.list_tables()) > 0
+        assert len(self.con.list_tables(like='functional')) == 1

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -99,6 +99,9 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
             (L(5).abs(), 5),
             (ibis.least(L(5), L(10), L(1)), 1),
             (ibis.greatest(L(5), L(10), L(1)), 10),
+
+            (L(5.5).round(), 6.0),
+            (L(5.556).round(2), 5.56),
         ]
         self._check_e2e_cases(cases)
 

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -44,9 +44,7 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
         pass
 
     def test_timestamp_cast_noop(self):
-        # SQLite does not have a physical date/time/timestamp type, so
-        # unfortunately cast to typestamp must be a no-op, and we have to trust
-        # that the user's data can actually be correctly parsed by SQLite.
+        # See GH #592
 
         at = self._to_sqla(self.alltypes)
 
@@ -66,6 +64,24 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
             (ic_casted, at.c.int_col)
         ]
         self._check_expr_cases(cases)
+
+    def test_timestamp_functions(self):
+        v = L('2015-09-01 14:48:05.359').cast('timestamp')
+
+        cases = [
+            (v.strftime('%Y%m%d'), '20150901'),
+
+            (v.year(), 2015),
+            (v.month(), 9),
+            (v.day(), 1),
+            (v.hour(), 14),
+            (v.minute(), 48),
+            (v.second(), 5),
+        ]
+        self._check_e2e_cases(cases)
+
+    def test_timestamp_now(self):
+        pass
 
     def test_binary_arithmetic(self):
         cases = [

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -70,8 +70,15 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
             (L('FOO').lower(), 'foo'),
 
             (L('foobar').find('bar'), 3),
-            (L('foobar').find('baz'), -1)
+            (L('foobar').find('baz'), -1),
 
+            (L('foobar').like('%bar'), True),
+            (L('foobar').like('foo%'), True),
+            (L('foobar').like('%baz%'), False),
+
+            (L('foobar').contains('bar'), True),
+            (L('foobar').contains('foo'), True),
+            (L('foobar').contains('baz'), False),
         ]
         self._check_e2e_cases(cases)
 

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -68,6 +68,10 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
 
             (L('foo').upper(), 'FOO'),
             (L('FOO').lower(), 'foo'),
+
+            (L('foobar').find('bar'), 3),
+            (L('foobar').find('baz'), -1)
+
         ]
         self._check_e2e_cases(cases)
 

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -105,6 +105,18 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
         ]
         self._check_e2e_cases(cases)
 
+    def test_regexp(self):
+        pytest.skip('NYI: Requires adding regex udf with sqlite3')
+
+        v = L('abcd')
+        v2 = L('1222')
+        cases = [
+            (v.re_search('[a-z]'), True),
+            (v.re_search('[\d]+'), False),
+            (v2.re_search('[\d]+'), True),
+        ]
+        self._check_e2e_cases(cases)
+
     def test_fillna_nullif(self):
         cases = [
             (ibis.NA.fillna(5), 5),

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -90,6 +90,8 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
             (L('foobar').contains('bar'), True),
             (L('foobar').contains('foo'), True),
             (L('foobar').contains('baz'), False),
+
+            (L('foobarfoo').replace('foo', 'H'), 'HbarH'),
         ]
         self._check_e2e_cases(cases)
 

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -66,6 +66,8 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
         self._check_expr_cases(cases)
 
     def test_timestamp_functions(self):
+        from datetime import datetime
+
         v = L('2015-09-01 14:48:05.359').cast('timestamp')
 
         cases = [
@@ -78,11 +80,12 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
             (v.minute(), 48),
             (v.second(), 5),
             (v.millisecond(), 359),
+
+            # there could be pathological failure at midnight somewhere, but
+            # that's okay
+            (ibis.now().strftime('%Y%m%d'), datetime.now().strftime('%Y%m%d'))
         ]
         self._check_e2e_cases(cases)
-
-    def test_timestamp_now(self):
-        pass
 
     def test_binary_arithmetic(self):
         cases = [

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -77,6 +77,7 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
             (v.hour(), 14),
             (v.minute(), 48),
             (v.second(), 5),
+            (v.millisecond(), 359),
         ]
         self._check_e2e_cases(cases)
 

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -93,10 +93,12 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
         ]
         self._check_e2e_cases(cases)
 
-    def test_fillna(self):
+    def test_fillna_nullif(self):
         cases = [
             (ibis.NA.fillna(5), 5),
             (L(5).fillna(10), 5),
+            (L(5).nullif(5), None),
+            (L(10).nullif(5), 10),
         ]
         self._check_e2e_cases(cases)
 

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest  # noqa
+
 from .common import SQLiteTests
 from ibis.compat import unittest
 from ibis import literal as L
@@ -104,6 +106,24 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
             (d > 20).ifelse(10, -20).abs(),
         ]
         self._execute_projection(t, exprs)
+
+    def test_union(self):
+        pytest.skip('union not working yet')
+
+        t = self.alltypes
+
+        expr = (t.group_by('string_col')
+                .aggregate(t.double_col.sum().name('foo'))
+                .sort_by('string_col'))
+
+        t1 = expr.limit(4)
+        t2 = expr.limit(4, offset=4)
+        t3 = expr.limit(8)
+
+        result = t1.union(t2).execute()
+        expected = t3.execute()
+
+        assert (result.string_col == expected.string_col).all()
 
     def test_aggregations_execute(self):
         table = self.alltypes.limit(100)

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -15,7 +15,6 @@
 from .common import SQLiteTests
 from ibis.compat import unittest
 from ibis import literal as L
-import ibis
 
 import sqlalchemy as sa
 

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -53,6 +53,15 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
         ]
         self._check_e2e_cases(cases)
 
+    def test_typeof(self):
+        cases = [
+            (L('foo_bar').typeof(), 'text'),
+            (L(5).typeof(), 'integer'),
+            (ibis.NA.typeof(), 'null'),
+            (L(1.2345).typeof(), 'real'),
+        ]
+        self._check_e2e_cases(cases)
+
     def test_string_functions(self):
         cases = [
             (L('foo_bar').length(), 7),

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -93,6 +93,13 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
         ]
         self._check_e2e_cases(cases)
 
+    def test_fillna(self):
+        cases = [
+            (ibis.NA.fillna(5), 5),
+            (L(5).fillna(10), 5),
+        ]
+        self._check_e2e_cases(cases)
+
     def test_coalesce(self):
         pass
 

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -51,6 +51,26 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
         ]
         self._check_e2e_cases(cases)
 
+    def test_string_functions(self):
+        cases = [
+            (L('foo_bar').length(), 7),
+
+            (L('foo_bar').left(3), 'foo'),
+            (L('foo_bar').right(3), 'bar'),
+
+            (L('foo_bar').substr(0, 3), 'foo'),
+            (L('foo_bar').substr(4, 3), 'bar'),
+            (L('foo_bar').substr(1), 'oo_bar'),
+
+            (L('   foo   ').lstrip(), 'foo   '),
+            (L('   foo   ').rstrip(), '   foo'),
+            (L('   foo   ').strip(), 'foo'),
+
+            (L('foo').upper(), 'FOO'),
+            (L('FOO').lower(), 'foo'),
+        ]
+        self._check_e2e_cases(cases)
+
     def test_aggregations_execute(self):
         table = self.alltypes.limit(100)
 

--- a/ibis/sql/tests/test_sqlalchemy.py
+++ b/ibis/sql/tests/test_sqlalchemy.py
@@ -149,10 +149,30 @@ class TestSQLAlchemySelect(unittest.TestCase, ExprTestCases):
 
         self._check_expr_cases(cases)
 
+    def test_between(self):
+        sat = self.sa_alltypes
+        sd = sat.c.double_col
+        d = self.alltypes.double_col
+
+        cases = [
+            (d.between(5, 10), sd.between(L(5), L(10))),
+        ]
+        self._check_expr_cases(cases)
+
+    def test_isnull_notnull(self):
+        sat = self.sa_alltypes
+        sd = sat.c.double_col
+        d = self.alltypes.double_col
+
+        cases = [
+            (d.isnull(), sd.is_(sa.null())),
+            (d.notnull(), sd.isnot(sa.null())),
+        ]
+        self._check_expr_cases(cases)
+
     def test_negate(self):
         sat = self.sa_alltypes
         sd = sat.c.double_col
-
         d = self.alltypes.double_col
         cases = [
             (-(d > 0), sql.not_(sd > L(0)))

--- a/ibis/sql/tests/test_sqlalchemy.py
+++ b/ibis/sql/tests/test_sqlalchemy.py
@@ -180,6 +180,26 @@ class TestSQLAlchemySelect(unittest.TestCase, ExprTestCases):
 
         self._check_expr_cases(cases)
 
+    def test_coalesce(self):
+        sat = self.sa_alltypes
+        sd = sat.c.double_col
+        sf = sat.c.float_col
+
+        d = self.alltypes.double_col
+        f = self.alltypes.float_col
+        null = sa.null()
+
+        v1 = ibis.NA
+        v2 = (d > 30).ifelse(d, ibis.NA)
+        v3 = f
+
+        cases = [
+            (ibis.coalesce(v2, v1, v3),
+             sa.func.coalesce(sa.case([(sd > L(30), sd)], else_=null),
+                              null, sf))
+        ]
+        self._check_expr_cases(cases)
+
     def test_named_expr(self):
         sat = self.sa_alltypes
         d = self.alltypes.double_col
@@ -212,6 +232,12 @@ class TestSQLAlchemySelect(unittest.TestCase, ExprTestCases):
         for ibis_joined, joined_sqla in joins:
             expected = sa.select([rt, nt]).select_from(joined_sqla)
             self._compare_sqla(ibis_joined, expected)
+
+    def test_simple_case(self):
+        pass
+
+    def test_searched_case(self):
+        pass
 
     def test_where_simple_comparisons(self):
         expr = self._case_where_simple_comparisons()

--- a/ibis/sql/tests/test_sqlalchemy.py
+++ b/ibis/sql/tests/test_sqlalchemy.py
@@ -149,6 +149,17 @@ class TestSQLAlchemySelect(unittest.TestCase, ExprTestCases):
 
         self._check_expr_cases(cases)
 
+    def test_negate(self):
+        sat = self.sa_alltypes
+        sd = sat.c.double_col
+
+        d = self.alltypes.double_col
+        cases = [
+            (-(d > 0), sql.not_(sd > L(0)))
+        ]
+
+        self._check_expr_cases(cases)
+
     def test_named_expr(self):
         sat = self.sa_alltypes
         d = self.alltypes.double_col


### PR DESCRIPTION
Adds translation rules for most SQLite built-in non-esoteric functions. Closes #596.