### PR TITLE
TST: Added coverage computation on jenkins runs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+branch: True
+omit: ibis/tests/*,
+      ibis/*/tests/*,
+      ibis/cloudpickle.py

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ dist
 *.egg-info
 # coverage
 .coverage
+coverage.xml
 
 # OS generated files
 .directory


### PR DESCRIPTION
Coverage data gets reported to codecov.io/github/cloudera/ibis

Fixes #598.