### PR TITLE
BUG: Fix any-to-exists transform foreign ref analysis logic

### DIFF
--- a/ibis/impala/tests/test_exprs.py
+++ b/ibis/impala/tests/test_exprs.py
@@ -910,7 +910,7 @@ class TestStringBuiltins(unittest.TestCase, ExprSQLTest):
         self._check_expr_cases(cases)
 
 
-class TestImpalaExprs(ImpalaE2E, unittest.TestCase):
+class TestImpalaExprs(ImpalaE2E, unittest.TestCase, ExprTestCases):
 
     def test_embedded_identifier_quoting(self):
         t = self.con.table('functional_alltypes')
@@ -1433,6 +1433,10 @@ class TestImpalaExprs(ImpalaE2E, unittest.TestCase):
 
         proj_table = g.mutate(proj_exprs)
         proj_table.execute()
+
+    def test_anti_join_self_reference_works(self):
+        case = self._case_self_reference_limit_exists()
+        self.con.explain(case)
 
     def test_tpch_self_join_failure(self):
         region = self.con.table('tpch_region')

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -620,6 +620,7 @@ class _ExtractSubqueries(object):
         self.visit(expr.op().table)
 
     def _visit_Limit(self, expr):
+        self.observe(expr)
         self.visit(expr.op().table)
 
     def _visit_Union(self, expr):

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -606,8 +606,15 @@ class _ExtractSubqueries(object):
         self.visit(node.right)
 
     _visit_physical_table = _extract_noop
-    _visit_ExistsSubquery = _extract_noop
-    _visit_NotExistsSubquery = _extract_noop
+
+    def _visit_Exists(self, expr):
+        node = expr.op()
+        self.visit(node.foreign_table)
+        for pred in node.predicates:
+            self.visit(pred)
+
+    _visit_ExistsSubquery = _visit_Exists
+    _visit_NotExistsSubquery = _visit_Exists
 
     def _visit_Aggregation(self, expr):
         self.observe(expr)

--- a/ibis/sql/tests/test_compiler.py
+++ b/ibis/sql/tests/test_compiler.py
@@ -671,12 +671,28 @@ class ExprTestCases(object):
 
         return semi, anti
 
+    def _case_self_reference_limit_exists(self):
+        alltypes = self.con.table('functional_alltypes')
+        t = alltypes.limit(100)
+        t2 = t.view()
+        return t[-(t.string_col == t2.string_col).any()]
+
+    def _case_limit_cte_extract(self):
+        alltypes = self.con.table('functional_alltypes')
+        t = alltypes.limit(100)
+        t2 = t.view()
+        return t.join(t2).projection(t)
+
 
 class TestSelectSQL(unittest.TestCase, ExprTestCases):
 
     @classmethod
     def setUpClass(cls):
         cls.con = MockConnection()
+
+    def _compare_sql(self, expr, expected):
+        result = to_sql(expr)
+        assert result == expected
 
     def test_nameless_table(self):
         # Ensure that user gets some kind of sensible error
@@ -1699,6 +1715,39 @@ WHERE NOT EXISTS (
   WHERE t0.`string_col` = t1.`string_col`
 )"""
         assert result == expected
+
+    def test_self_reference_limit_exists(self):
+        case = self._case_self_reference_limit_exists()
+
+        expected = """\
+WITH t0 AS (
+  SELECT *
+  FROM functional_alltypes t0
+  LIMIT 100
+)
+SELECT t1.*
+FROM t0 t1
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM t0 t2
+  WHERE t1.`string_col` = t2.`string_col`
+)"""
+        self._compare_sql(case, expected)
+
+    def test_limit_cte_extract(self):
+        case = self._case_limit_cte_extract()
+
+        expected = """\
+WITH t0 AS (
+  SELECT *
+  FROM functional_alltypes
+  LIMIT 100
+)
+SELECT t0.*
+FROM t0
+  CROSS JOIN t0 t1"""
+
+        self._compare_sql(case, expected)
 
     def test_sort_by(self):
         cases = self._case_sort_by()

--- a/ibis/sql/tests/test_compiler.py
+++ b/ibis/sql/tests/test_compiler.py
@@ -1722,15 +1722,15 @@ WHERE NOT EXISTS (
         expected = """\
 WITH t0 AS (
   SELECT *
-  FROM functional_alltypes t0
+  FROM functional_alltypes
   LIMIT 100
 )
-SELECT t1.*
-FROM t0 t1
+SELECT t0.*
+FROM t0
 WHERE NOT EXISTS (
   SELECT 1
-  FROM t0 t2
-  WHERE t1.`string_col` = t2.`string_col`
+  FROM t0 t1
+  WHERE t0.`string_col` = t1.`string_col`
 )"""
         self._compare_sql(case, expected)
 

--- a/ibis/sql/transforms.py
+++ b/ibis/sql/transforms.py
@@ -85,12 +85,13 @@ class AnyToExistsTransform(object):
     def _visit_table(self, expr):
         node = expr.op()
 
-        if isinstance(node, (ops.PhysicalTable, ops.SelfReference)):
+        if isinstance(node, ir.BlockingTableNode):
             self._ref_check(expr)
 
-        for arg in node.flat_args():
-            if isinstance(arg, ir.Expr):
-                self._visit(arg)
+        if not isinstance(node, ir.BlockingTableNode):
+            for arg in node.flat_args():
+                if isinstance(arg, ir.Expr):
+                    self._visit(arg)
 
     def _ref_check(self, expr):
         node = expr.op()


### PR DESCRIPTION
Close #645. Add testing for CTE extraction on subqueries embedded in semi/anti-join filters