### PR TITLE
ENH: More rigorous pandas integration in create_table / insert

### DIFF
--- a/ibis/client.py
+++ b/ibis/client.py
@@ -47,7 +47,7 @@ class Query(object):
     def execute(self):
         # synchronous by default
         with self.client._execute(self.compiled_ddl, results=True) as cur:
-            result = self._fetch_from_cursor(cur)
+            result = self._fetch(cur)
 
         return self._wrap_result(result)
 
@@ -56,7 +56,7 @@ class Query(object):
             result = self.result_wrapper(result)
         return result
 
-    def _fetch_from_cursor(self, cursor):
+    def _fetch(self, cursor):
         import pandas as pd
         rows = cursor.fetchall()
         # TODO(wesm): please evaluate/reimpl to optimize for perf/memory

--- a/ibis/compat.py
+++ b/ibis/compat.py
@@ -45,6 +45,7 @@ if PY3:
         return list(x.values())
     from decimal import Decimal
     import unittest.mock as mock
+    range = __builtin__.range
 else:
     import cPickle
 
@@ -63,5 +64,6 @@ else:
         return x.values()
 
     import mock
+    range = xrange
 
 integer_types = six.integer_types + (np.integer,)

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -151,7 +151,6 @@ class TypeOf(ValueOp):
     output_type = rules.shape_like_arg(0, 'string')
 
 
-
 class Negate(UnaryOp):
 
     input_type = [number]

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -255,7 +255,10 @@ class ImpalaCursor(object):
         self.cursor.cancel_operation()
 
     def fetchall(self, columnar=False):
-        return self.cursor.fetchall(columnar=columnar)
+        if columnar:
+            return self.cursor.fetchcolumnar()
+        else:
+            return self.cursor.fetchall()
 
 
 class ImpalaQuery(Query):

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -1662,6 +1662,8 @@ class DataFrameWriter(object):
     def cleanup(self):
         for path in self.temp_hdfs_dirs:
             self.hdfs.rmdir(path)
+        self.temp_hdfs_dirs = []
+        self.csv_dir = None
 
 
 def pandas_to_ibis_schema(frame):

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -956,7 +956,7 @@ class ImpalaClient(SQLClient):
         """
         pass
 
-    def insert(self, table_name, expr, database=None, overwrite=False,
+    def insert(self, table_name, obj, database=None, overwrite=False,
                validate=True):
         """
         Insert into existing table
@@ -964,7 +964,7 @@ class ImpalaClient(SQLClient):
         Parameters
         ----------
         table_name : string
-        expr : TableExpr
+        obj : TableExpr or pandas DataFrame
         database : string, default None
         overwrite : boolean, default False
           If True, will replace existing contents of table
@@ -979,6 +979,11 @@ class ImpalaClient(SQLClient):
         # Completely overwrite contents
         con.insert('my_table', table_expr, overwrite=True)
         """
+        if isinstance(obj, pd.DataFrame):
+            writer, expr = self._write_dataframe(obj)
+        else:
+            expr = obj
+
         if validate:
             existing_schema = self.get_schema(table_name, database=database)
             insert_schema = expr.schema()

--- a/ibis/impala/ddl.py
+++ b/ibis/impala/ddl.py
@@ -253,11 +253,12 @@ class NoFormat(object):
 class DelimitedFormat(object):
 
     def __init__(self, path, delimiter=None, escapechar=None,
-                 lineterminator=None):
+                 na_rep=None, lineterminator=None):
         self.path = path
         self.delimiter = delimiter
         self.escapechar = escapechar
         self.lineterminator = lineterminator
+        self.na_rep = na_rep
 
     def to_ddl(self):
         buf = StringIO()
@@ -275,6 +276,10 @@ class DelimitedFormat(object):
                       .format(self.lineterminator))
 
         buf.write("\nLOCATION '{0}'".format(self.path))
+
+        if self.na_rep is not None:
+            buf.write("\nTBLPROPERTIES('serialization.null.format'='{0}')"
+                      .format(self.na_rep))
 
         return buf.getvalue()
 
@@ -304,10 +309,11 @@ class CreateTableDelimited(CreateTableWithSchema):
 
     def __init__(self, table_name, path, schema,
                  delimiter=None, escapechar=None, lineterminator=None,
-                 external=True, **kwargs):
+                 na_rep=None, external=True, **kwargs):
         table_format = DelimitedFormat(path, delimiter=delimiter,
                                        escapechar=escapechar,
-                                       lineterminator=lineterminator)
+                                       lineterminator=lineterminator,
+                                       na_rep=na_rep)
         CreateTableWithSchema.__init__(self, table_name, schema,
                                        table_format, external=external,
                                        **kwargs)

--- a/ibis/impala/pandas_interop.py
+++ b/ibis/impala/pandas_interop.py
@@ -1,0 +1,199 @@
+# Copyright 2014 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from posixpath import join as pjoin
+
+import pandas.core.common as pdcom
+import pandas as pd
+
+import ibis.common as com
+
+from ibis.config import options
+from ibis.util import log
+import ibis.compat as compat
+import ibis.expr.datatypes as itypes
+import ibis.util as util
+
+
+# ----------------------------------------------------------------------
+# pandas integration
+
+
+def pandas_col_to_ibis_type(col):
+    import numpy as np
+    dty = col.dtype
+
+    # datetime types
+    if pdcom.is_datetime64_dtype(dty):
+        if pdcom.is_datetime64_ns_dtype(dty):
+            return 'timestamp'
+        else:
+            raise com.IbisTypeError("Column {0} has dtype {1}, which is "
+                                    "datetime64-like but does "
+                                    "not use nanosecond units"
+                                    .format(col.name, dty))
+    if pdcom.is_timedelta64_dtype(dty):
+        print("Warning: encoding a timedelta64 as an int64")
+        return 'int64'
+
+    if pdcom.is_categorical_dtype(dty):
+        return itypes.Category(len(col.cat.categories))
+
+    if pdcom.is_bool_dtype(dty):
+        return 'boolean'
+
+    # simple numerical types
+    if issubclass(dty.type, np.int8):
+        return 'int8'
+    if issubclass(dty.type, np.int16):
+        return 'int16'
+    if issubclass(dty.type, np.int32):
+        return 'int32'
+    if issubclass(dty.type, np.int64):
+        return 'int64'
+    if issubclass(dty.type, np.float32):
+        return 'float'
+    if issubclass(dty.type, np.float64):
+        return 'double'
+    if issubclass(dty.type, np.uint8):
+        return 'int16'
+    if issubclass(dty.type, np.uint16):
+        return 'int32'
+    if issubclass(dty.type, np.uint32):
+        return 'int64'
+    if issubclass(dty.type, np.uint64):
+        raise com.IbisTypeError("Column {0} is an unsigned int64"
+                                .format(col.name))
+
+    if pdcom.is_object_dtype(dty):
+        return _infer_object_dtype(col)
+
+    raise com.IbisTypeError("Column {0} is dtype {1}".format(col.name, dty))
+
+
+def _infer_object_dtype(arr):
+    # TODO: accelerate with Cython/C
+
+    BOOLEAN, STRING = 0, 1
+    state = BOOLEAN
+
+    avalues = arr.values if isinstance(arr, pd.Series) else arr
+    nulls = pd.isnull(avalues)
+
+    if nulls.any():
+        for i in compat.range(len(avalues)):
+            if state == BOOLEAN:
+                if not nulls[i] and not pdcom.is_bool(avalues[i]):
+                    state = STRING
+            elif state == STRING:
+                break
+        if state == BOOLEAN:
+            return 'boolean'
+        elif state == STRING:
+            return 'string'
+    else:
+        return pd.lib.infer_dtype(avalues)
+
+
+class DataFrameWriter(object):
+
+    """
+    Interface class for writing pandas objects to Impala tables
+
+    Class takes ownership of any data written to HDFS
+    """
+    def __init__(self, client, df):
+        self.client = client
+        self.hdfs = client.hdfs
+
+        self.df = df
+
+        self.temp_hdfs_dirs = []
+        self.csv_dir = None
+
+    def write_csv(self):
+        import csv
+        import tempfile
+
+        temp_hdfs_dir = pjoin(options.impala.temp_hdfs_path,
+                              'pandas_{0}'.format(util.guid()))
+        with tempfile.NamedTemporaryFile() as f:
+            # Write the DataFrame to the temporary file path
+            if options.verbose:
+                log('Writing DataFrame to temporary file')
+
+            self.df.to_csv(f, header=False, index=False,
+                           sep=',',
+                           quoting=csv.QUOTE_NONE,
+                           escapechar='\\',
+                           na_rep='#NULL')
+            f.seek(0)
+
+            # Write the file to HDFS
+            hdfs_path = pjoin(temp_hdfs_dir, '0.csv')
+
+            if options.verbose:
+                log('Writing CSV to HDFS: {0}'.format(hdfs_path))
+
+            self.hdfs.put(hdfs_path, f)
+
+            # Keep track of the temporary HDFS file
+            self.temp_hdfs_dirs.append(temp_hdfs_dir)
+
+            self.csv_dir = temp_hdfs_dir
+
+        return temp_hdfs_dir
+
+    def get_schema(self):
+        # define a temporary table using delimited data
+        return pandas_to_ibis_schema(self.df)
+
+    def delimited_table(self, name=None, database=None):
+        if self.csv_dir is None:
+            self.write_csv()
+
+        temp_delimited_name = 'ibis_tmp_pandas_{0}'.format(util.guid())
+        schema = self.get_schema()
+
+        return self.client.delimited_file(self.csv_dir, schema,
+                                          name=temp_delimited_name,
+                                          database=database,
+                                          delimiter=',',
+                                          na_rep='#NULL',
+                                          escapechar='\\\\',
+                                          external=True,
+                                          persist=False)
+
+    def __del__(self):
+        try:
+            self.cleanup()
+        except com.IbisError:
+            pass
+
+    def cleanup(self):
+        for path in self.temp_hdfs_dirs:
+            self.hdfs.rmdir(path)
+        self.temp_hdfs_dirs = []
+        self.csv_dir = None
+
+
+def pandas_to_ibis_schema(frame):
+    from ibis.expr.api import schema
+    # no analog for decimal in pandas
+    pairs = []
+    for col_name in frame:
+        ibis_type = pandas_col_to_ibis_type(frame[col_name])
+        pairs.append((col_name, ibis_type))
+    return schema(pairs)

--- a/ibis/impala/tests/test_ddl.py
+++ b/ibis/impala/tests/test_ddl.py
@@ -462,7 +462,7 @@ class TestDDLOperations(ImpalaE2E, unittest.TestCase):
         expr = self.alltypes
         table_name = _random_table_name()
 
-        self.con.create_table(table_name, expr=expr, path=tmp_path,
+        self.con.create_table(table_name, obj=expr, path=tmp_path,
                               database=self.test_data_db)
         self.temp_tables.append('.'.join([self.test_data_db, table_name]))
         assert self.hdfs.exists(tmp_path)
@@ -477,7 +477,7 @@ class TestDDLOperations(ImpalaE2E, unittest.TestCase):
         expr = self.alltypes.limit(50)
 
         table_name = util.guid()
-        self.con.create_table(table_name, expr=expr)
+        self.con.create_table(table_name, obj=expr)
         self.temp_tables.append(table_name)
 
         try:

--- a/ibis/impala/tests/test_pandas_interop.py
+++ b/ibis/impala/tests/test_pandas_interop.py
@@ -138,24 +138,27 @@ class TestPandasSchemaInference(unittest.TestCase):
 
 
 exhaustive_df = pd.DataFrame({
-    'bigint_col': np.int64([0, 10, 20, 30, 40, 50, 60, 70, 80, 90]),
-    'bool_col': np.bool_([True, False, True, False, True, None,
-                          True, False, True, False]),
+    'bigint_col': np.array([0, 10, 20, 30, 40, 50, 60, 70, 80, 90],
+                           dtype='i8'),
+    'bool_col': np.array([True, False, True, False, True, None,
+                          True, False, True, False], dtype=np.bool_),
+    # 'bool_obj_col': np.array([True, False, np.nan, False, True, np.nan,
+    #                           True, np.nan, True, False], dtype=np.object_),
     'date_string_col': ['11/01/10', None, '11/01/10', '11/01/10',
                         '11/01/10', '11/01/10', '11/01/10', '11/01/10',
                         '11/01/10', '11/01/10'],
-    'double_col': np.float64([0.0, 10.1, None, 30.299999999999997,
-                              40.399999999999999, 50.5, 60.599999999999994,
-                              70.700000000000003, 80.799999999999997,
-                              90.899999999999991]),
-    'float_col': np.float32([None, 1.1000000238418579, 2.2000000476837158,
-                             3.2999999523162842, 4.4000000953674316, 5.5,
-                             6.5999999046325684, 7.6999998092651367,
-                             8.8000001907348633,
-                             9.8999996185302734]),
-    'int_col': np.int32([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    'double_col': np.array([0.0, 10.1, np.nan, 30.299999999999997,
+                            40.399999999999999, 50.5, 60.599999999999994,
+                            70.700000000000003, 80.799999999999997,
+                            90.899999999999991], dtype=np.float64),
+    'float_col': np.array([np.nan, 1.1000000238418579, 2.2000000476837158,
+                           3.2999999523162842, 4.4000000953674316, 5.5,
+                           6.5999999046325684, 7.6999998092651367,
+                           8.8000001907348633,
+                           9.8999996185302734], dtype='f4'),
+    'int_col': np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype='i4'),
     'month': [11, 11, 11, 11, 2, 11, 11, 11, 11, 11],
-    'smallint_col': np.int16([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    'smallint_col': np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype='i2'),
     'string_col': ['0', '1', None, 'double , whammy', '4', '5',
                    '6', '7', '8', '9'],
     'timestamp_col': [pd.Timestamp('2010-11-01 00:00:00'),
@@ -168,8 +171,8 @@ exhaustive_df = pd.DataFrame({
                       pd.Timestamp('2010-11-01 00:07:00.210000'),
                       pd.Timestamp('2010-11-01 00:08:00.280000'),
                       pd.Timestamp('2010-11-01 00:09:00.360000')],
-    'tinyint_col': np.int8([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-    'year': [2010, 2010, 2010, 2010, 2010, 2010, 2010, 2010, 2010, 2010]})
+    'tinyint_col': np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype='i1'),
+    'year': [2010, 2010, 2010, 2010, 2010, 2009, 2009, 2009, 2009, 2009]})
 
 
 class TestPandasInterop(ImpalaE2E, unittest.TestCase):

--- a/ibis/impala/tests/test_pandas_interop.py
+++ b/ibis/impala/tests/test_pandas_interop.py
@@ -182,7 +182,7 @@ class TestPandasInterop(ImpalaE2E, unittest.TestCase):
         self._check_roundtrip(self.alltypes)
 
     def test_writer_cleanup_deletes_hdfs_dir(self):
-        writer = DataFrameWriter(self.alltypes)
+        writer = DataFrameWriter(self.con, self.alltypes)
         writer.write_csv()
 
         path = writer.csv_dir

--- a/ibis/impala/tests/test_pandas_interop.py
+++ b/ibis/impala/tests/test_pandas_interop.py
@@ -137,7 +137,7 @@ class TestPandasSchemaInference(unittest.TestCase):
         assert inferred == expected
 
 
-functional_alltypes_with_nulls = pd.DataFrame({
+exhaustive_df = pd.DataFrame({
     'bigint_col': np.int64([0, 10, 20, 30, 40, 50, 60, 70, 80, 90]),
     'bool_col': np.bool_([True, False, True, False, True, None,
                           True, False, True, False]),
@@ -156,7 +156,8 @@ functional_alltypes_with_nulls = pd.DataFrame({
     'int_col': np.int32([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
     'month': [11, 11, 11, 11, 2, 11, 11, 11, 11, 11],
     'smallint_col': np.int16([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-    'string_col': ['0', '1', None, '3', '4', '5', '6', '7', '8', '9'],
+    'string_col': ['0', '1', None, 'double , \nwhammy', '4', '5',
+                   '6', '7', '8', '9'],
     'timestamp_col': [pd.Timestamp('2010-11-01 00:00:00'),
                       None,
                       pd.Timestamp('2010-11-01 00:02:00.100000'),
@@ -204,8 +205,8 @@ class TestPandasInterop(ImpalaE2E, unittest.TestCase):
         df = table.execute()
         assert_frame_equal(df, self.alltypes)
 
-    def test_round_trip_non_int_missing_data(self):
-        self._check_roundtrip(functional_alltypes_with_nulls)
+    def test_round_trip_exhaustive(self):
+        self._check_roundtrip(exhaustive_df)
 
     def _check_roundtrip(self, df):
         writer = DataFrameWriter(self.con, df)

--- a/ibis/impala/tests/test_pandas_interop.py
+++ b/ibis/impala/tests/test_pandas_interop.py
@@ -20,7 +20,7 @@ import pandas as pd
 
 from ibis.compat import unittest
 from ibis.common import IbisTypeError
-from ibis.impala.client import pandas_to_ibis_schema, DataFrameWriter
+from ibis.impala.pandas_interop import pandas_to_ibis_schema, DataFrameWriter
 from ibis.impala.tests.common import ImpalaE2E
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
@@ -142,8 +142,8 @@ exhaustive_df = pd.DataFrame({
                            dtype='i8'),
     'bool_col': np.array([True, False, True, False, True, None,
                           True, False, True, False], dtype=np.bool_),
-    # 'bool_obj_col': np.array([True, False, np.nan, False, True, np.nan,
-    #                           True, np.nan, True, False], dtype=np.object_),
+    'bool_obj_col': np.array([True, False, np.nan, False, True, np.nan,
+                              True, np.nan, True, False], dtype=np.object_),
     'date_string_col': ['11/01/10', None, '11/01/10', '11/01/10',
                         '11/01/10', '11/01/10', '11/01/10', '11/01/10',
                         '11/01/10', '11/01/10'],

--- a/ibis/impala/tests/test_pandas_interop.py
+++ b/ibis/impala/tests/test_pandas_interop.py
@@ -13,50 +13,18 @@
 # limitations under the License.
 
 import numpy as np
-import pandas as pd
 import pytest
+
+from pandas.util.testing import assert_frame_equal
+import pandas as pd
 
 import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis.compat import unittest
 from ibis.common import IbisTypeError
-from ibis.impala.client import pandas_to_ibis_schema
+from ibis.impala.client import pandas_to_ibis_schema, DataFrameWriter
 from ibis.impala.tests.common import ImpalaE2E
-
-
-functional_alltypes_with_nulls = pd.DataFrame({
-    'bigint_col': np.int64([0, 10, 20, 30, 40, 50, 60, 70, 80, 90]),
-    'bool_col': np.bool_([True, False, True, False, True, None,
-                          True, False, True, False]),
-    'date_string_col': ['11/01/10', None, '11/01/10', '11/01/10',
-                        '11/01/10', '11/01/10', '11/01/10', '11/01/10',
-                        '11/01/10', '11/01/10'],
-    'double_col': np.float64([0.0, 10.1, None, 30.299999999999997,
-                              40.399999999999999, 50.5, 60.599999999999994,
-                              70.700000000000003, 80.799999999999997,
-                              90.899999999999991]),
-    'float_col': np.float32([None, 1.1000000238418579, 2.2000000476837158,
-                             3.2999999523162842, 4.4000000953674316, 5.5,
-                             6.5999999046325684, 7.6999998092651367,
-                             8.8000001907348633,
-                             9.8999996185302734]),
-    'int_col': np.int32([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-    'month': [11, 11, 11, 11, 2, 11, 11, 11, 11, 11],
-    'smallint_col': np.int16([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-    'string_col': ['0', '1', None, '3', '4', '5', '6', '7', '8', '9'],
-    'timestamp_col': [pd.Timestamp('2010-11-01 00:00:00'),
-                      None,
-                      pd.Timestamp('2010-11-01 00:02:00.100000'),
-                      pd.Timestamp('2010-11-01 00:03:00.300000'),
-                      pd.Timestamp('2010-11-01 00:04:00.600000'),
-                      pd.Timestamp('2010-11-01 00:05:00.100000'),
-                      pd.Timestamp('2010-11-01 00:06:00.150000'),
-                      pd.Timestamp('2010-11-01 00:07:00.210000'),
-                      pd.Timestamp('2010-11-01 00:08:00.280000'),
-                      pd.Timestamp('2010-11-01 00:09:00.360000')],
-    'tinyint_col': np.int8([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-    'year': [2010, 2010, 2010, 2010, 2010, 2010, 2010, 2010, 2010, 2010]})
 
 
 class TestPandasTypeInterop(unittest.TestCase):
@@ -168,16 +136,52 @@ class TestPandasSchemaInference(unittest.TestCase):
         assert inferred == expected
 
 
+functional_alltypes_with_nulls = pd.DataFrame({
+    'bigint_col': np.int64([0, 10, 20, 30, 40, 50, 60, 70, 80, 90]),
+    'bool_col': np.bool_([True, False, True, False, True, None,
+                          True, False, True, False]),
+    'date_string_col': ['11/01/10', None, '11/01/10', '11/01/10',
+                        '11/01/10', '11/01/10', '11/01/10', '11/01/10',
+                        '11/01/10', '11/01/10'],
+    'double_col': np.float64([0.0, 10.1, None, 30.299999999999997,
+                              40.399999999999999, 50.5, 60.599999999999994,
+                              70.700000000000003, 80.799999999999997,
+                              90.899999999999991]),
+    'float_col': np.float32([None, 1.1000000238418579, 2.2000000476837158,
+                             3.2999999523162842, 4.4000000953674316, 5.5,
+                             6.5999999046325684, 7.6999998092651367,
+                             8.8000001907348633,
+                             9.8999996185302734]),
+    'int_col': np.int32([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    'month': [11, 11, 11, 11, 2, 11, 11, 11, 11, 11],
+    'smallint_col': np.int16([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    'string_col': ['0', '1', None, '3', '4', '5', '6', '7', '8', '9'],
+    'timestamp_col': [pd.Timestamp('2010-11-01 00:00:00'),
+                      None,
+                      pd.Timestamp('2010-11-01 00:02:00.100000'),
+                      pd.Timestamp('2010-11-01 00:03:00.300000'),
+                      pd.Timestamp('2010-11-01 00:04:00.600000'),
+                      pd.Timestamp('2010-11-01 00:05:00.100000'),
+                      pd.Timestamp('2010-11-01 00:06:00.150000'),
+                      pd.Timestamp('2010-11-01 00:07:00.210000'),
+                      pd.Timestamp('2010-11-01 00:08:00.280000'),
+                      pd.Timestamp('2010-11-01 00:09:00.360000')],
+    'tinyint_col': np.int8([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    'year': [2010, 2010, 2010, 2010, 2010, 2010, 2010, 2010, 2010, 2010]})
+
+
 class TestPandasRoundTrip(ImpalaE2E, unittest.TestCase):
 
-    def test_round_trip(self):
-        pytest.skip('fails')
-
+    def test_alltypes_roundtrip(self):
         df1 = self.alltypes.execute()
-        df2 = self.con.pandas(df1, 'bamboo', database=self.tmp_db).execute()
-        assert (df1.columns == df2.columns).all()
-        assert (df1.dtypes == df2.dtypes).all()
-        assert (df1 == df2).all().all()
+
+        writer = DataFrameWriter(self.con, df1)
+        writer.write_csv()
+
+        table = writer.delimited_table()
+        df2 = table.execute()
+
+        assert_frame_equal(df1, df2)
 
     def test_round_trip_non_int_missing_data(self):
         pytest.skip('WM: hangs -- will investigate later')

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -486,7 +486,7 @@ compiles = AlchemyExprTranslator.compiles
 
 class AlchemyQuery(Query):
 
-    def _fetch_from_cursor(self, cursor):
+    def _fetch(self, cursor):
         # No guarantees that the DBAPI cursor has data types
         import pandas as pd
         proxy = cursor.proxy

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -862,7 +862,7 @@ def _adapt_expr(expr):
             return column_handler
 
         if isinstance(op, ops.TableColumn):
-            table_expr = op.table
+            table_expr = op.table[[op.name]]
             result_handler = _get_column(op.name)
         else:
             # Something more complicated.

--- a/ibis/sql/tests/test_compiler.py
+++ b/ibis/sql/tests/test_compiler.py
@@ -151,10 +151,14 @@ WHERE `c` > 0"""
         query = ast.queries[0]
 
         sql_query = query.compile()
-        expected = """SELECT `g`, sum(`f`) AS `total`
-FROM alltypes
-WHERE `c` > 0
-GROUP BY 1"""
+        expected = """\
+SELECT `g`
+FROM (
+  SELECT `g`, sum(`f`) AS `total`
+  FROM alltypes
+  WHERE `c` > 0
+  GROUP BY 1
+) t0"""
 
         assert sql_query == expected
 

--- a/ibis/tests/conftest.py
+++ b/ibis/tests/conftest.py
@@ -14,8 +14,14 @@
 
 from pytest import skip
 
+import ibis
 
 groups = ['hdfs', 'impala', 'madlib', 'sqlite']
+
+
+def pytest_configure(config):
+    if config.getvalue('iverbose'):
+        ibis.options.verbose = True
 
 
 def pytest_addoption(parser):
@@ -35,6 +41,9 @@ def pytest_addoption(parser):
                      help='Skip tests marked udf')
     parser.addoption('--skip-superuser', action='store_true', default=False,
                      help='Skip tests marked superuser')
+
+    parser.addoption('--iverbose', action='store_true', default=False,
+                     help='Set Ibis to verbose')
 
 
 def pytest_runtest_setup(item):

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -15,6 +15,8 @@
 import types
 import ibis.compat as compat
 
+from ibis.config import options
+
 
 def guid():
     try:
@@ -163,3 +165,12 @@ def deprecate(f, message):
         print(message)
         return f(*args, **kwargs)
     return g
+
+
+def to_stdout(x):
+    print(x)
+
+
+def log(msg):
+    if options.verbose:
+        (options.verbose_log or to_stdout)(msg)


### PR DESCRIPTION
Closes #197 

You can now use pandas DataFrame in many cases in `Client.create_table` and `Client.insert`. Note that this PR requires upstream Impyla.