### PR TITLE
BLD: Conda recipe to pull from trunk

### DIFF
--- a/conda-recipes/ibis-framework/bld.bat
+++ b/conda-recipes/ibis-framework/bld.bat
@@ -1,6 +1,8 @@
 "%PYTHON%" setup.py install
 if errorlevel 1 exit 1
 
+"%PYTHON%" -c "import ibis; print(ibis.__version__)" > __conda_version__.txt
+
 :: Add more build steps here, if they are necessary.
 
 :: See

--- a/conda-recipes/ibis-framework/build.sh
+++ b/conda-recipes/ibis-framework/build.sh
@@ -2,6 +2,8 @@
 
 $PYTHON setup.py install
 
+$PYTHON -c "import ibis; print(ibis.__version__)" > __conda_version__.txt
+
 # Add more build steps here, if they are necessary.
 
 # See

--- a/conda-recipes/ibis-framework/meta.yaml
+++ b/conda-recipes/ibis-framework/meta.yaml
@@ -1,11 +1,9 @@
 package:
   name: ibis-framework
-  version: "0.5.1"
+  version: "SETBYINSTALL"
 
 source:
-  fn: ibis-framework-0.5.1.tar.gz
-  url: https://pypi.python.org/packages/source/i/ibis-framework/ibis-framework-0.5.1.tar.gz
-  md5: ff9242537cde30785faac3a551408c9b
+  path: ../..
 
 requirements:
   build:

--- a/conda-recipes/impyla/meta.yaml
+++ b/conda-recipes/impyla/meta.yaml
@@ -3,12 +3,11 @@ package:
   version: "0.11.2"
 
 source:
-  fn: impyla-0.11.2.tar.gz
-  url: https://pypi.python.org/packages/source/i/impyla/impyla-0.11.2.tar.gz
-  md5: 350385753a8eecf1408e419586df0e9d
+  git_url: https://github.com/cloudera/impyla
 
 build:
-  preserve_egg_dir: True
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  string: py{{ environ.get('PY_VER').replace('.', '') }}_{{ environ.get('GIT_BUILD_STR', 'GIT_STUB') }}
 
 requirements:
   build:


### PR DESCRIPTION
Updated conda recipes so that they can be used to build conda packages for the current state of the repo rather than rely on build from pypi