### PR TITLE
ENH: add various Impala DDL wrapper functions

### DIFF
--- a/ibis/compat.py
+++ b/ibis/compat.py
@@ -44,6 +44,7 @@ if PY3:
     def dict_values(x):
         return list(x.values())
     from decimal import Decimal
+    import unittest.mock as mock
 else:
     import cPickle
 
@@ -60,5 +61,7 @@ else:
 
     def dict_values(x):
         return x.values()
+
+    import mock
 
 integer_types = six.integer_types + (np.integer,)

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -1348,7 +1348,7 @@ class ImpalaClient(SQLClient):
 
         Parameters
         ----------
-        name : string, optional
+        name : string
           Table name. Can be fully qualified (with database)
         database : string, optional
         """
@@ -1362,6 +1362,22 @@ class ImpalaClient(SQLClient):
             result[c] = result[c].str.strip()
 
         return result
+
+    def show_files(self, name, database=None):
+        """
+        Retrieve results of SHOW FILES command for a table. See Impala
+        documentation for more.
+
+        Parameters
+        ----------
+        name : string
+          Table name. Can be fully qualified (with database)
+        database : string, optional
+        """
+        stmt = self._table_command('SHOW FILES IN',
+                                   name, database=database)
+        query = ImpalaQuery(self, stmt)
+        return query.execute()
 
     def _table_command(self, cmd, name, database=None):
         qualified_name = self._fully_qualified_name(name, database)
@@ -1455,6 +1471,12 @@ class ImpalaTable(ir.TableExpr, DatabaseEntity):
         Return results of DESCRIBE FORMATTED statement
         """
         return self._client.describe_formatted(self._qualified_name)
+
+    def show_files(self):
+        """
+        Return results of SHOW FILES statement
+        """
+        return self._client.show_files(self._qualified_name)
 
     def drop(self):
         """

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -1309,6 +1309,23 @@ class ImpalaClient(SQLClient):
 
         self._execute(stmt)
 
+    def invalidate_metadata(self, name=None, database=None):
+        """
+        Issue INVALIDATE METADATA command, optionally only applying to a
+        particular table. See Impala documentation.
+
+        Parameters
+        ----------
+        name : string, optional
+          Table name. Can be fully qualified (with database)
+        database : string, optional
+        """
+        stmt = 'INVALIDATE METADATA'
+        if name is not None:
+            qualified_name = self._fully_qualified_name(name, database)
+            stmt = '{0} {1}'.format(stmt, qualified_name)
+        self._execute(stmt)
+
     def _adapt_types(self, descr):
         names = []
         adapted_types = []

--- a/ibis/impala/tests/test_ddl.py
+++ b/ibis/impala/tests/test_ddl.py
@@ -618,6 +618,17 @@ class TestDDLOperations(ImpalaE2E, unittest.TestCase):
                                        results=True)
             assert isinstance(desc, pd.DataFrame)
 
+    def test_show_files(self):
+        t = self.con.table('functional_alltypes')
+        qualified_name = '{0}.`{1}`'.format(self.test_data_db,
+                                            'functional_alltypes')
+        with self._patch_execute() as ex_mock:
+            desc = t.show_files()
+            ex_mock.assert_called_with('SHOW FILES IN {0}'
+                                       .format(qualified_name),
+                                       results=True)
+            assert isinstance(desc, pd.DataFrame)
+
     def test_drop_table_or_view(self):
         t = self.db.functional_alltypes
 

--- a/ibis/impala/tests/test_ddl.py
+++ b/ibis/impala/tests/test_ddl.py
@@ -564,7 +564,12 @@ class TestDDLOperations(ImpalaE2E, unittest.TestCase):
             t.insert(to_insert.limit(10))
 
     def test_compute_stats(self):
-        self.con.table('functional_alltypes').compute_stats()
+        t = self.con.table('functional_alltypes')
+
+        t.compute_stats()
+        t.compute_stats(incremental=True)
+
+        self.con.compute_stats('functional_alltypes')
 
     def test_drop_table_or_view(self):
         t = self.db.functional_alltypes

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,9 @@ if PY26:
     requirements.append('argparse')
     requirements.append('unittest2')
 
+if PY2:
+    requirements.append('mock')
+
 
 if COMMS_EXT_ENABLED:
     import numpy as np


### PR DESCRIPTION
INVALIDATE METADATA, REFRESH, SHOW FILES IN, DESCRIBE FORMATTED. Also added support for COMPUTE INCREMENTAL STATS in existing function with `incremental=True`.

Close #713, #710, #709, #708. 