### PR TITLE
Use storage when creating with a schema

### DIFF
--- a/ibis/impala/ddl.py
+++ b/ibis/impala/ddl.py
@@ -277,6 +277,8 @@ class CreateTableWithSchema(CreateTable):
         format_ddl = self.table_format.to_ddl()
         if format_ddl:
             buf.write(format_ddl)
+        else:
+            buf.write(self._storage())
 
         buf.write(self._location())
 


### PR DESCRIPTION
When creating a table with a schema and setting the format to parquet, the table is created as text (the impala default) since `stored as parquet` is never inserted.
Added a `_storage` call to insert the `stored as parquet` similar to other tables.

Thoughts?

```
db.create_table(table_name, schema=schema, format='parquet')
```