### PR TITLE
BUG: respect storage passed storage format to ImpalaClient.create_table

### DIFF
--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -51,7 +51,8 @@ class ImpalaDatabase(Database):
 
     def create_table(self, table_name, obj=None, **kwargs):
         """
-        Dispatch to ImpalaClient.create_table. See docs for more
+        Dispatch to ImpalaClient.create_table. See that function's docstring
+        for more
         """
         return self.client.create_table(table_name, obj=obj,
                                         database=self.name, **kwargs)
@@ -852,7 +853,7 @@ class ImpalaClient(SQLClient):
                                  path=location)
         elif schema is not None:
             statement = ddl.CreateTableWithSchema(
-                table_name, schema, ddl.NoFormat(),
+                table_name, schema,
                 database=database,
                 format=format,
                 can_exist=force,

--- a/ibis/impala/ddl.py
+++ b/ibis/impala/ddl.py
@@ -234,7 +234,7 @@ class CreateTableParquet(CreateTable):
 
 class CreateTableWithSchema(CreateTable):
 
-    def __init__(self, table_name, schema, table_format, **kwargs):
+    def __init__(self, table_name, schema, table_format=None, **kwargs):
         self.schema = schema
         self.table_format = table_format
 
@@ -274,9 +274,10 @@ class CreateTableWithSchema(CreateTable):
             buf.write('\n')
             _push_schema(self.schema)
 
-        format_ddl = self.table_format.to_ddl()
-        if format_ddl:
-            buf.write(format_ddl)
+        if self.table_format is not None:
+            buf.write(self.table_format.to_ddl())
+        else:
+            buf.write(self._storage())
 
         buf.write(self._location())
 
@@ -286,7 +287,7 @@ class CreateTableWithSchema(CreateTable):
 class NoFormat(object):
 
     def to_ddl(self):
-        return None
+        return ''
 
 
 class DelimitedFormat(object):
@@ -345,6 +346,18 @@ class AvroFormat(object):
         props = {'avro.schema.literal': schema}
         buf.write('\n')
         buf.write(format_tblproperties(props))
+        return buf.getvalue()
+
+
+class ParquetFormat(object):
+
+    def __init__(self, path):
+        self.path = path
+
+    def to_ddl(self):
+        buf = StringIO()
+        buf.write('\nSTORED AS PARQUET')
+        buf.write("\nLOCATION '{0}'".format(self.path))
         return buf.getvalue()
 
 

--- a/ibis/impala/tests/test_ddl.py
+++ b/ibis/impala/tests/test_ddl.py
@@ -296,8 +296,8 @@ FROM test1""".format(path)
                               ('bar', 'int8'),
                               ('baz', 'int16')])
         statement = ddl.CreateTableWithSchema('another_table', schema,
-                                              ddl.NoFormat(),
                                               can_exist=False,
+                                              format='parquet',
                                               path=path, database='foo')
         result = statement.compile()
 
@@ -306,6 +306,7 @@ CREATE TABLE foo.`another_table`
 (`foo` string,
  `bar` tinyint,
  `baz` smallint)
+STORED AS PARQUET
 LOCATION '{0}'""".format(path)
         assert result == expected
 


### PR DESCRIPTION
As noted in #790, the `format` parameter of `create_table` was not being respected in `create_table`, and Impala's default output format is text. This changes things to use Parquet as the default output format. 

Closes #790 
Closes #771 
