### PR TITLE
Added conda installer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ SQL engine support near on the horizon:
 Read the project blog at http://blog.ibis-project.org.
 
 Learn much more at http://ibis-project.org.
+
+Current release from Anaconda.org [![Anaconda-Server Badge](https://anaconda.org/conda-forge/ibis-framework/badges/version.svg)](https://anaconda.org/conda-forge/ibis-framework)


### PR DESCRIPTION
This is the installer link from https://github.com/conda-forge/ibis-framework-feedstock

If you want i can add whoever wants to assist the release process as a maintainer of the recipes and their dependencies.

Not sure where in the readme we want these links.