### PR TITLE
Fix CTE extraction inside Union subqueries

### DIFF
--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -385,8 +385,13 @@ class ImpalaUnion(comp.Union):
         left_set = context.get_compiled_expr(self.left)
         right_set = context.get_compiled_expr(self.right)
 
-        query = '{0}\n{1}\n{2}'.format(left_set, union_keyword, right_set)
-        return query
+        # XXX: hack of all trades - our right relation has a CTE
+        # TODO: factor out common subqueries in the union
+        if right_set.startswith('WITH'):
+            format_string = '({0})\n{1}\n({2})'
+        else:
+            format_string = '{0}\n{1}\n{2}'
+        return format_string.format(left_set, union_keyword, right_set)
 
 
 # ---------------------------------------------------------------------

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -382,8 +382,8 @@ class ImpalaUnion(comp.Union):
         else:
             union_keyword = 'UNION ALL'
 
-        left_set = context.get_compiled_expr(self.left)
-        right_set = context.get_compiled_expr(self.right)
+        left_set = context.get_compiled_expr(self.left, isolated=True)
+        right_set = context.get_compiled_expr(self.right, isolated=True)
 
         # XXX: hack of all trades - our right relation has a CTE
         # TODO: factor out common subqueries in the union

--- a/ibis/impala/tests/test_exprs.py
+++ b/ibis/impala/tests/test_exprs.py
@@ -1550,3 +1550,17 @@ FROM functional_alltypes"""
 
         assert isinstance(t.varchar_col, api.StringArray)
         assert isinstance(t.char_col, api.StringArray)
+
+    def test_unions_with_ctes(self):
+        t = self.con.table('functional_alltypes')
+
+        expr1 = (t.group_by(['tinyint_col', 'string_col'])
+                 .aggregate(t.double_col.sum().name('metric')))
+        expr2 = expr1.view()
+
+        join1 = (expr1.join(expr2, expr1.string_col == expr2.string_col)
+                 [[expr1]])
+        join2 = join1.view()
+
+        expr = join1.union(join2)
+        self.con.explain(expr)

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -409,14 +409,17 @@ class AlchemyContext(comp.QueryContext):
         self.dialect = kwargs.pop('dialect', AlchemyDialect)
         comp.QueryContext.__init__(self, *args, **kwargs)
 
-    def subcontext(self):
-        return type(self)(dialect=self.dialect, parent=self)
+    def subcontext(self, isolated=False):
+        if not isolated:
+            return type(self)(dialect=self.dialect, parent=self)
+        else:
+            return type(self)(dialect=self.dialect)
 
     def _to_sql(self, expr, ctx):
         return to_sqlalchemy(expr, context=ctx)
 
-    def _compile_subquery(self, expr):
-        sub_ctx = self.subcontext()
+    def _compile_subquery(self, expr, isolated=False):
+        sub_ctx = self.subcontext(isolated=isolated)
         return self._to_sql(expr, sub_ctx)
 
     def has_table(self, expr, parent_contexts=False):

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -926,8 +926,8 @@ class QueryContext(object):
 
         self._table_key_memo = {}
 
-    def _compile_subquery(self, expr):
-        sub_ctx = self.subcontext()
+    def _compile_subquery(self, expr, isolated=False):
+        sub_ctx = self.subcontext(isolated=isolated)
         return self._to_sql(expr, sub_ctx)
 
     def _to_sql(self, expr, ctx):
@@ -943,7 +943,7 @@ class QueryContext(object):
     def set_always_alias(self):
         self.always_alias = True
 
-    def get_compiled_expr(self, expr):
+    def get_compiled_expr(self, expr, isolated=False):
         this = self.top_context
 
         key = self._get_table_key(expr)
@@ -954,7 +954,7 @@ class QueryContext(object):
         if isinstance(op, ops.SQLQueryResult):
             result = op.query
         else:
-            result = self._compile_subquery(expr)
+            result = self._compile_subquery(expr, isolated=isolated)
 
         this.subquery_memo[key] = result
         return result
@@ -1009,8 +1009,11 @@ class QueryContext(object):
         self.extracted_subexprs.add(key)
         self.make_alias(expr)
 
-    def subcontext(self):
-        return type(self)(indent=self.indent, parent=self)
+    def subcontext(self, isolated=False):
+        if not isolated:
+            return type(self)(indent=self.indent, parent=self)
+        else:
+            return type(self)(indent=self.indent)
 
     # Maybe temporary hacks for correlated / uncorrelated subqueries
 

--- a/ibis/sql/tests/test_compiler.py
+++ b/ibis/sql/tests/test_compiler.py
@@ -1459,41 +1459,25 @@ GROUP BY 1"""
         expr = join1.union(join2)
         result = to_sql(expr)
         expected = """\
-(WITH t1 AS (
+(WITH t0 AS (
   SELECT `a`, `g`, sum(`f`) AS `metric`
   FROM alltypes
   GROUP BY 1, 2
 )
-SELECT t1.*
-FROM (
-  SELECT `a`, `g`, sum(`f`) AS `metric`
-  FROM alltypes
-  GROUP BY 1, 2
-) t1
-  INNER JOIN (
-    SELECT `a`, `g`, sum(`f`) AS `metric`
-    FROM alltypes
-    GROUP BY 1, 2
-  ) t1
-    ON t1.`g` = t1.`g`)
+SELECT t0.*
+FROM t0
+  INNER JOIN t0 t1
+    ON t0.`g` = t1.`g`)
 UNION ALL
-(WITH t1 AS (
+(WITH t0 AS (
   SELECT `a`, `g`, sum(`f`) AS `metric`
   FROM alltypes
   GROUP BY 1, 2
 )
-SELECT t1.*
-FROM (
-  SELECT `a`, `g`, sum(`f`) AS `metric`
-  FROM alltypes
-  GROUP BY 1, 2
-) t1
-  INNER JOIN (
-    SELECT `a`, `g`, sum(`f`) AS `metric`
-    FROM alltypes
-    GROUP BY 1, 2
-  ) t1
-    ON t1.`g` = t1.`g`)"""
+SELECT t0.*
+FROM t0
+  INNER JOIN t0 t1
+    ON t0.`g` = t1.`g`)"""
         assert result == expected
 
     def test_subquery_factor_correlated_subquery(self):

--- a/ibis/sql/tests/test_compiler.py
+++ b/ibis/sql/tests/test_compiler.py
@@ -1449,7 +1449,6 @@ GROUP BY 1"""
 
     def test_subquery_in_union(self):
         t = self.con.table('alltypes')
-        tt = self.con.table('alltypes')
 
         expr1 = t.group_by(['a', 'g']).aggregate(t.f.sum().name('metric'))
         expr2 = expr1.view()


### PR DESCRIPTION
Closes #836, #821. Per comments in #836 there's still some cleanup to be done here.

#666 is still not fixed -- we should look at CTE extraction that can happen across the union subqueries. for now it's OK to have some redundancy. 