### PR TITLE
Refactor tests to use pytest conventions

### DIFF
--- a/ibis/expr/tests/conftest.py
+++ b/ibis/expr/tests/conftest.py
@@ -13,3 +13,69 @@
 # limitations under the License.
 
 from ibis.tests.conftest import *  # noqa
+from ibis.expr.tests.mocks import MockConnection
+
+import pytest
+import ibis
+import ibis.expr.datatypes as dt
+
+
+@pytest.fixture
+def schema():
+    return [
+        ('a', 'int8'),
+        ('b', 'int16'),
+        ('c', 'int32'),
+        ('d', 'int64'),
+        ('e', 'float'),
+        ('f', 'double'),
+        ('g', 'string'),
+        ('h', 'boolean'),
+    ]
+
+
+@pytest.fixture
+def schema_dict(schema):
+    return dict(schema)
+
+
+@pytest.fixture
+def table(schema):
+    return ibis.table(schema, name='schema')
+
+
+@pytest.fixture
+def int_cols(schema):
+    schema = ibis.schema(schema)
+    return [
+        col for col, type in zip(schema.names, schema.types)
+        if isinstance(type, dt.Integer)
+    ]
+
+
+@pytest.fixture
+def bool_cols(schema):
+    schema = ibis.schema(schema)
+    return [
+        col for col, type in zip(schema.names, schema.types)
+        if isinstance(type, dt.Boolean)
+    ]
+
+
+@pytest.fixture
+def float_cols(schema):
+    schema = ibis.schema(schema)
+    return [
+        col for col, type in zip(schema.names, schema.types)
+        if isinstance(type, dt.Floating)
+    ]
+
+
+@pytest.fixture(params=list('abcdefh'))
+def numeric_cols(request):
+    return request.param
+
+
+@pytest.fixture
+def con():
+    return MockConnection()

--- a/ibis/expr/tests/conftest.py
+++ b/ibis/expr/tests/conftest.py
@@ -44,35 +44,28 @@ def table(schema):
     return ibis.table(schema, name='schema')
 
 
-@pytest.fixture
-def int_cols(schema):
-    schema = ibis.schema(schema)
-    return [
-        col for col, type in zip(schema.names, schema.types)
-        if isinstance(type, dt.Integer)
-    ]
+@pytest.fixture(params=list('abcdh'))
+def int_col(request):
+    return request.param
 
 
-@pytest.fixture
-def bool_cols(schema):
-    schema = ibis.schema(schema)
-    return [
-        col for col, type in zip(schema.names, schema.types)
-        if isinstance(type, dt.Boolean)
-    ]
+@pytest.fixture(params=list('h'))
+def bool_col(request):
+    return request.param
 
 
-@pytest.fixture
-def float_cols(schema):
-    schema = ibis.schema(schema)
-    return [
-        col for col, type in zip(schema.names, schema.types)
-        if isinstance(type, dt.Floating)
-    ]
+@pytest.fixture(params=list('ef'))
+def float_col(request):
+    return request.param
 
 
 @pytest.fixture(params=list('abcdefh'))
-def numeric_cols(request):
+def numeric_col(request):
+    return request.param
+
+
+@pytest.fixture(params=list('abcdefgh'))
+def col(request):
     return request.param
 
 

--- a/ibis/expr/tests/mocks.py
+++ b/ibis/expr/tests/mocks.py
@@ -362,29 +362,3 @@ class MockConnection(SQLClient):
         ast = self._build_ast_ensure_limit(expr, limit)
         queries = [q.compile() for q in ast.queries]
         return queries[0] if len(queries) == 1 else queries
-
-
-_all_types_schema = [
-    ('a', 'int8'),
-    ('b', 'int16'),
-    ('c', 'int32'),
-    ('d', 'int64'),
-    ('e', 'float'),
-    ('f', 'double'),
-    ('g', 'string'),
-    ('h', 'boolean')
-]
-
-
-class BasicTestCase(object):
-
-    def setUp(self):
-        self.schema = _all_types_schema
-        self.schema_dict = dict(self.schema)
-        self.table = ibis.table(self.schema, 'schema')
-
-        self.int_cols = ['a', 'b', 'c', 'd']
-        self.bool_cols = ['h']
-        self.float_cols = ['e', 'f']
-
-        self.con = MockConnection()

--- a/ibis/expr/tests/test_analysis.py
+++ b/ibis/expr/tests/test_analysis.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import ibis
 
 from ibis.compat import unittest
-from ibis.expr.tests.mocks import BasicTestCase
 import ibis.expr.analysis as L
 import ibis.expr.operations as ops
 import ibis.common as com
@@ -26,262 +27,272 @@ from ibis.tests.util import assert_equal
 # Place to collect esoteric expression analysis bugs and tests
 
 
-class TestTableExprBasics(BasicTestCase, unittest.TestCase):
+def test_rewrite_substitute_distinct_tables(con):
+    t = con.table('test1')
+    tt = con.table('test1')
 
-    def test_rewrite_substitute_distinct_tables(self):
-        t = self.con.table('test1')
-        tt = self.con.table('test1')
+    expr = t[t.c > 0]
+    expr2 = tt[tt.c > 0]
 
-        expr = t[t.c > 0]
-        expr2 = tt[tt.c > 0]
+    metric = t.f.sum().name('metric')
+    expr3 = expr.aggregate(metric)
 
-        metric = t.f.sum().name('metric')
-        expr3 = expr.aggregate(metric)
+    result = L.sub_for(expr3, [(expr2, t)])
+    expected = t.aggregate(metric)
 
-        result = L.sub_for(expr3, [(expr2, t)])
-        expected = t.aggregate(metric)
+    assert_equal(result, expected)
 
-        assert_equal(result, expected)
 
-    def test_rewrite_join_projection_without_other_ops(self):
-        # See #790, predicate pushdown in joins not supported
+def test_rewrite_join_projection_without_other_ops(con):
+    # See #790, predicate pushdown in joins not supported
 
-        # Star schema with fact table
-        table = self.con.table('star1')
-        table2 = self.con.table('star2')
-        table3 = self.con.table('star3')
+    # Star schema with fact table
+    table = con.table('star1')
+    table2 = con.table('star2')
+    table3 = con.table('star3')
 
-        filtered = table[table['f'] > 0]
-
-        pred1 = table['foo_id'] == table2['foo_id']
-        pred2 = filtered['bar_id'] == table3['bar_id']
-
-        j1 = filtered.left_join(table2, [pred1])
-        j2 = j1.inner_join(table3, [pred2])
+    filtered = table[table['f'] > 0]
 
-        # Project out the desired fields
-        view = j2[[filtered, table2['value1'], table3['value2']]]
+    pred1 = table['foo_id'] == table2['foo_id']
+    pred2 = filtered['bar_id'] == table3['bar_id']
 
-        # Construct the thing we expect to obtain
-        ex_pred2 = table['bar_id'] == table3['bar_id']
-        ex_expr = (table.left_join(table2, [pred1])
-                   .inner_join(table3, [ex_pred2]))
+    j1 = filtered.left_join(table2, [pred1])
+    j2 = j1.inner_join(table3, [pred2])
 
-        rewritten_proj = L.substitute_parents(view)
-        op = rewritten_proj.op()
-
-        assert not op.table.equals(ex_expr)
-
-    def test_rewrite_past_projection(self):
-        table = self.con.table('test1')
+    # Project out the desired fields
+    view = j2[[filtered, table2['value1'], table3['value2']]]
 
-        # Rewrite past a projection
-        table3 = table[['c', 'f']]
-        expr = table3['c'] == 2
+    # Construct the thing we expect to obtain
+    ex_pred2 = table['bar_id'] == table3['bar_id']
+    ex_expr = (table.left_join(table2, [pred1])
+               .inner_join(table3, [ex_pred2]))
 
-        result = L.substitute_parents(expr)
-        expected = table['c'] == 2
-        assert_equal(result, expected)
+    rewritten_proj = L.substitute_parents(view)
+    op = rewritten_proj.op()
 
-        # Unsafe to rewrite past projection
-        table5 = table[(table.f * 2).name('c'), table.f]
-        expr = table5['c'] == 2
-        result = L.substitute_parents(expr)
-        assert result is expr
+    assert not op.table.equals(ex_expr)
 
-    def test_multiple_join_deeper_reference(self):
-        # Join predicates down the chain might reference one or more root
-        # tables in the hierarchy.
-        table1 = ibis.table({'key1': 'string', 'key2': 'string',
-                            'value1': 'double'})
-        table2 = ibis.table({'key3': 'string', 'value2': 'double'})
-        table3 = ibis.table({'key4': 'string', 'value3': 'double'})
 
-        joined = table1.inner_join(table2, [table1['key1'] == table2['key3']])
-        joined2 = joined.inner_join(table3, [table1['key2'] == table3['key4']])
+def test_rewrite_past_projection(con):
+    table = con.table('test1')
 
-        # it works, what more should we test here?
-        materialized = joined2.materialize()
-        repr(materialized)
+    # Rewrite past a projection
+    table3 = table[['c', 'f']]
+    expr = table3['c'] == 2
 
-    def test_filter_on_projected_field(self):
-        # See #173. Impala and other SQL engines do not allow filtering on a
-        # just-created alias in a projection
-        region = self.con.table('tpch_region')
-        nation = self.con.table('tpch_nation')
-        customer = self.con.table('tpch_customer')
-        orders = self.con.table('tpch_orders')
+    result = L.substitute_parents(expr)
+    expected = table['c'] == 2
+    assert_equal(result, expected)
 
-        fields_of_interest = [customer,
-                              region.r_name.name('region'),
-                              orders.o_totalprice.name('amount'),
-                              orders.o_orderdate
-                              .cast('timestamp').name('odate')]
+    # Unsafe to rewrite past projection
+    table5 = table[(table.f * 2).name('c'), table.f]
+    expr = table5['c'] == 2
+    result = L.substitute_parents(expr)
+    assert result is expr
 
-        all_join = (
-            region.join(nation, region.r_regionkey == nation.n_regionkey)
-            .join(customer, customer.c_nationkey == nation.n_nationkey)
-            .join(orders, orders.o_custkey == customer.c_custkey))
 
-        tpch = all_join[fields_of_interest]
+def test_multiple_join_deeper_reference():
+    # Join predicates down the chain might reference one or more root
+    # tables in the hierarchy.
+    table1 = ibis.table({'key1': 'string', 'key2': 'string',
+                        'value1': 'double'})
+    table2 = ibis.table({'key3': 'string', 'value2': 'double'})
+    table3 = ibis.table({'key4': 'string', 'value3': 'double'})
 
-        # Correlated subquery, yikes!
-        t2 = tpch.view()
-        conditional_avg = t2[(t2.region == tpch.region)].amount.mean()
+    joined = table1.inner_join(table2, [table1['key1'] == table2['key3']])
+    joined2 = joined.inner_join(table3, [table1['key2'] == table3['key4']])
 
-        # `amount` is part of the projection above as an aliased field
-        amount_filter = tpch.amount > conditional_avg
-
-        result = tpch.filter([amount_filter])
+    # it works, what more should we test here?
+    materialized = joined2.materialize()
+    repr(materialized)
 
-        # Now then! Predicate pushdown here is inappropriate, so we check that
-        # it didn't occur.
-        assert isinstance(result.op(), ops.Selection)
-        assert result.op().table is tpch
 
-    def test_bad_join_predicate_raises(self):
-        # Join predicate references a derived table, but we can salvage and
-        # rewrite it to get the join semantics out
-        # see ibis #74
-        table = ibis.table([
-            ('c', 'int32'),
-            ('f', 'double'),
-            ('g', 'string')
-        ], 'foo_table')
-
-        table2 = ibis.table([
-            ('key', 'string'),
-            ('value', 'double')
-        ], 'bar_table')
-
-        filter_pred = table['f'] > 0
-        table3 = table[filter_pred]
-
-        with self.assertRaises(com.ExpressionError):
-            table.inner_join(table2, [table3['g'] == table2['key']])
-
-        # expected = table.inner_join(table2, [table['g'] == table2['key']])
-        # assert_equal(result, expected)
-
-    def test_filter_self_join(self):
-        # GH #667
-        purchases = ibis.table([('region', 'string'),
-                                ('kind', 'string'),
-                                ('user', 'int64'),
-                                ('amount', 'double')], 'purchases')
-
-        metric = purchases.amount.sum().name('total')
-        agged = (purchases.group_by(['region', 'kind'])
-                 .aggregate(metric))
-
-        left = agged[agged.kind == 'foo']
-        right = agged[agged.kind == 'bar']
-
-        cond = left.region == right.region
-        joined = left.join(right, cond)
+def test_filter_on_projected_field(con):
+    # See #173. Impala and other SQL engines do not allow filtering on a
+    # just-created alias in a projection
+    region = con.table('tpch_region')
+    nation = con.table('tpch_nation')
+    customer = con.table('tpch_customer')
+    orders = con.table('tpch_orders')
 
-        # unmodified by analysis
-        assert_equal(joined.op().predicates[0], cond)
+    fields_of_interest = [customer,
+                          region.r_name.name('region'),
+                          orders.o_totalprice.name('amount'),
+                          orders.o_orderdate
+                          .cast('timestamp').name('odate')]
 
-        metric = (left.total - right.total).name('diff')
-        what = [left.region, metric]
-        projected = joined.projection(what)
+    all_join = (
+        region.join(nation, region.r_regionkey == nation.n_regionkey)
+        .join(customer, customer.c_nationkey == nation.n_nationkey)
+        .join(orders, orders.o_custkey == customer.c_custkey))
 
-        proj_exprs = projected.op().selections
+    tpch = all_join[fields_of_interest]
 
-        # proj exprs unaffected by analysis
-        assert_equal(proj_exprs[0], left.region)
-        assert_equal(proj_exprs[1], metric)
+    # Correlated subquery, yikes!
+    t2 = tpch.view()
+    conditional_avg = t2[(t2.region == tpch.region)].amount.mean()
 
-    # def test_fuse_filter_projection(self):
-    #     data = ibis.table([('kind', 'string'),
-    #                        ('year', 'int64')], 'data')
+    # `amount` is part of the projection above as an aliased field
+    amount_filter = tpch.amount > conditional_avg
 
-    #     pred = data.year == 2010
+    result = tpch.filter([amount_filter])
 
-    #     result = data.projection(['kind'])[pred]
-    #     expected = data.filter(pred).kind
+    # Now then! Predicate pushdown here is inappropriate, so we check that
+    # it didn't occur.
+    assert isinstance(result.op(), ops.Selection)
+    assert result.op().table is tpch
 
-    #     assert isinstance(result, ops.Selection)
-    #     assert result.equals(expected)
 
-    def test_fuse_projection_sort_by(self):
-        pass
+def test_bad_join_predicate_raises():
+    # Join predicate references a derived table, but we can salvage and
+    # rewrite it to get the join semantics out
+    # see ibis #74
+    table = ibis.table([
+        ('c', 'int32'),
+        ('f', 'double'),
+        ('g', 'string')
+    ], 'foo_table')
 
-    def test_fuse_filter_sort_by(self):
-        pass
+    table2 = ibis.table([
+        ('key', 'string'),
+        ('value', 'double')
+    ], 'bar_table')
 
-    # Refactoring deadpool
+    filter_pred = table['f'] > 0
+    table3 = table[filter_pred]
 
-    def test_no_rewrite(self):
-        table = self.con.table('test1')
+    with pytest.raises(com.ExpressionError):
+        table.inner_join(table2, [table3['g'] == table2['key']])
 
-        # Substitution not fully possible if we depend on a new expr in a
-        # projection
-        table4 = table[['c', (table['c'] * 2).name('foo')]]
-        expr = table4['c'] == table4['foo']
-        result = L.substitute_parents(expr)
-        expected = table['c'] == table4['foo']
-        assert_equal(result, expected)
+    # expected = table.inner_join(table2, [table['g'] == table2['key']])
+    # assert_equal(result, expected)
 
-    # def test_projection_with_join_pushdown_rewrite_refs(self):
-    #     # Observed this expression IR issue in a TopK-rewrite context
-    #     table1 = ibis.table([
-    #         ('a_key1', 'string'),
-    #         ('a_key2', 'string'),
-    #         ('a_value', 'double')
-    #     ], 'foo')
 
-    #     table2 = ibis.table([
-    #         ('b_key1', 'string'),
-    #         ('b_name', 'string'),
-    #         ('b_value', 'double')
-    #     ], 'bar')
+def test_filter_self_join():
+    # GH #667
+    purchases = ibis.table([('region', 'string'),
+                            ('kind', 'string'),
+                            ('user', 'int64'),
+                            ('amount', 'double')], 'purchases')
 
-    #     table3 = ibis.table([
-    #         ('c_key2', 'string'),
-    #         ('c_name', 'string')
-    #     ], 'baz')
+    metric = purchases.amount.sum().name('total')
+    agged = (purchases.group_by(['region', 'kind'])
+             .aggregate(metric))
 
-    #     proj = (table1.inner_join(table2, [('a_key1', 'b_key1')])
-    #             .inner_join(table3, [(table1.a_key2, table3.c_key2)])
-    #             [table1, table2.b_name.name('b'), table3.c_name.name('c'),
-    #              table2.b_value])
+    left = agged[agged.kind == 'foo']
+    right = agged[agged.kind == 'bar']
 
-    #     cases = [
-    #         (proj.a_value > 0, table1.a_value > 0),
-    #         (proj.b_value > 0, table2.b_value > 0)
-    #     ]
+    cond = left.region == right.region
+    joined = left.join(right, cond)
 
-    #     for higher_pred, lower_pred in cases:
-    #         result = proj.filter([higher_pred])
-    #         op = result.op()
-    #         assert isinstance(op, ops.Selection)
-    #         new_pred = op.predicates[0]
-    #         assert_equal(new_pred, lower_pred)
+    # unmodified by analysis
+    assert_equal(joined.op().predicates[0], cond)
 
-    # def test_rewrite_expr_with_parent(self):
-    #     table = self.con.table('test1')
+    metric = (left.total - right.total).name('diff')
+    what = [left.region, metric]
+    projected = joined.projection(what)
 
-    #     table2 = table[table['f'] > 0]
+    proj_exprs = projected.op().selections
 
-    #     expr = table2['c'] == 2
+    # proj exprs unaffected by analysis
+    assert_equal(proj_exprs[0], left.region)
+    assert_equal(proj_exprs[1], metric)
 
-    #     result = L.substitute_parents(expr)
-    #     expected = table['c'] == 2
-    #     assert_equal(result, expected)
 
-    # def test_rewrite_distinct_but_equal_objects(self):
-    #     t = self.con.table('test1')
-    #     t_copy = self.con.table('test1')
+# def test_fuse_filter_projection():
+#     data = ibis.table([('kind', 'string'),
+#                        ('year', 'int64')], 'data')
 
-    #     table2 = t[t_copy['f'] > 0]
+#     pred = data.year == 2010
 
-    #     expr = table2['c'] == 2
+#     result = data.projection(['kind'])[pred]
+#     expected = data.filter(pred).kind
 
-    #     result = L.substitute_parents(expr)
-    #     expected = t['c'] == 2
-    #     assert_equal(result, expected)
+#     assert isinstance(result, ops.Selection)
+#     assert result.equals(expected)
+
+
+@pytest.mark.xfail
+def test_fuse_projection_sort_by():
+    assert False
+
+
+@pytest.mark.xfail
+def test_fuse_filter_sort_by():
+    assert False
+
+
+# Refactoring deadpool
+
+def test_no_rewrite(con):
+    table = con.table('test1')
+
+    # Substitution not fully possible if we depend on a new expr in a
+    # projection
+    table4 = table[['c', (table['c'] * 2).name('foo')]]
+    expr = table4['c'] == table4['foo']
+    result = L.substitute_parents(expr)
+    expected = table['c'] == table4['foo']
+    assert_equal(result, expected)
+
+# def test_projection_with_join_pushdown_rewrite_refs():
+#     # Observed this expression IR issue in a TopK-rewrite context
+#     table1 = ibis.table([
+#         ('a_key1', 'string'),
+#         ('a_key2', 'string'),
+#         ('a_value', 'double')
+#     ], 'foo')
+
+#     table2 = ibis.table([
+#         ('b_key1', 'string'),
+#         ('b_name', 'string'),
+#         ('b_value', 'double')
+#     ], 'bar')
+
+#     table3 = ibis.table([
+#         ('c_key2', 'string'),
+#         ('c_name', 'string')
+#     ], 'baz')
+
+#     proj = (table1.inner_join(table2, [('a_key1', 'b_key1')])
+#             .inner_join(table3, [(table1.a_key2, table3.c_key2)])
+#             [table1, table2.b_name.name('b'), table3.c_name.name('c'),
+#              table2.b_value])
+
+#     cases = [
+#         (proj.a_value > 0, table1.a_value > 0),
+#         (proj.b_value > 0, table2.b_value > 0)
+#     ]
+
+#     for higher_pred, lower_pred in cases:
+#         result = proj.filter([higher_pred])
+#         op = result.op()
+#         assert isinstance(op, ops.Selection)
+#         new_pred = op.predicates[0]
+#         assert_equal(new_pred, lower_pred)
+
+# def test_rewrite_expr_with_parent():
+#     table = self.con.table('test1')
+
+#     table2 = table[table['f'] > 0]
+
+#     expr = table2['c'] == 2
+
+#     result = L.substitute_parents(expr)
+#     expected = table['c'] == 2
+#     assert_equal(result, expected)
+
+# def test_rewrite_distinct_but_equal_objects():
+#     t = self.con.table('test1')
+#     t_copy = self.con.table('test1')
+
+#     table2 = t[t_copy['f'] > 0]
+
+#     expr = table2['c'] == 2
+
+#     result = L.substitute_parents(expr)
+#     expected = t['c'] == 2
+#     assert_equal(result, expected)
 
 
 def test_join_table_choice():

--- a/ibis/expr/tests/test_table.py
+++ b/ibis/expr/tests/test_table.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from ibis.expr.types import ArrayExpr, TableExpr, RelationError
 from ibis.common import ExpressionError
 from ibis.expr.datatypes import array_type
@@ -21,7 +23,7 @@ import ibis.expr.operations as ops
 import ibis
 
 from ibis.compat import unittest
-from ibis.expr.tests.mocks import MockConnection, BasicTestCase
+from ibis.expr.tests.mocks import MockConnection
 
 import ibis.common as com
 import ibis.config as config
@@ -30,1107 +32,1199 @@ import ibis.config as config
 from ibis.tests.util import assert_equal
 
 
-class TestTableExprBasics(BasicTestCase, unittest.TestCase):
-
-    def test_empty_schema(self):
-        table = api.table([], 'foo')
-        assert len(table.schema()) == 0
-
-    def test_columns(self):
-        t = self.con.table('alltypes')
-        result = t.columns
-        expected = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
-        assert result == expected
-
-    def test_view_new_relation(self):
-        # For assisting with self-joins and other self-referential operations
-        # where we need to be able to treat instances of the same TableExpr as
-        # semantically distinct
-        #
-        # This thing is not exactly a projection, since it has no semantic
-        # meaning when it comes to execution
-        tview = self.table.view()
-
-        roots = tview._root_tables()
-        assert len(roots) == 1
-        assert roots[0] is tview.op()
-
-    def test_get_type(self):
-        for k, v in self.schema_dict.items():
-            assert self.table._get_type(k) == v
-
-    def test_getitem_column_select(self):
-        for k, v in self.schema_dict.items():
-            col = self.table[k]
-
-            # Make sure it's the right type
-            assert isinstance(col, ArrayExpr)
-            assert isinstance(col, array_type(v))
-
-            # Ensure we have a field selection with back-reference to the table
-            parent = col.parent()
-            assert isinstance(parent, ops.TableColumn)
-            assert parent.parent() is self.table
-
-    def test_getitem_attribute(self):
-        result = self.table.a
-        assert_equal(result, self.table['a'])
-
-        assert 'a' in dir(self.table)
-
-        # Project and add a name that conflicts with a TableExpr built-in
-        # attribute
-        view = self.table[[self.table, self.table['a'].name('schema')]]
-        assert not isinstance(view.schema, ArrayExpr)
-
-    def test_projection(self):
-        cols = ['f', 'a', 'h']
-
-        proj = self.table[cols]
-        assert isinstance(proj, TableExpr)
-        assert isinstance(proj.op(), ops.Selection)
-
-        assert proj.schema().names == cols
-        for c in cols:
-            expr = proj[c]
-            assert isinstance(expr, type(self.table[c]))
-
-    def test_projection_no_list(self):
-        expr = (self.table.f * 2).name('bar')
-        result = self.table.select(expr)
-        expected = self.table.projection([expr])
-        assert_equal(result, expected)
-
-    def test_projection_with_exprs(self):
-        # unnamed expr to test
-        mean_diff = (self.table['a'] - self.table['c']).mean()
-
-        col_exprs = [self.table['b'].log().name('log_b'),
-                     mean_diff.name('mean_diff')]
-
-        proj = self.table[col_exprs + ['g']]
-        schema = proj.schema()
-        assert schema.names == ['log_b', 'mean_diff', 'g']
-        assert schema.types == ['double', 'double', 'string']
-
-        # Test with unnamed expr
-        self.assertRaises(ExpressionError, self.table.projection,
-                          ['g', self.table['a'] - self.table['c']])
-
-    def test_projection_duplicate_names(self):
-        self.assertRaises(com.IntegrityError, self.table.projection,
-                          [self.table.c, self.table.c])
-
-    def test_projection_invalid_root(self):
-        schema1 = {
-            'foo': 'double',
-            'bar': 'int32'
-        }
-
-        left = api.table(schema1, name='foo')
-        right = api.table(schema1, name='bar')
-
-        exprs = [right['foo'], right['bar']]
-        self.assertRaises(RelationError, left.projection, exprs)
-
-    def test_projection_unnamed_literal_interactive_blowup(self):
-        # #147 and #153 alike
-        table = self.con.table('functional_alltypes')
-
-        with config.option_context('interactive', True):
-            try:
-                table.select([table.bigint_col, ibis.literal(5)])
-            except Exception as e:
-                assert 'named' in e.args[0]
-
-    def test_projection_of_aggregated(self):
-        # Fully-formed aggregations "block"; in a projection, column
-        # expressions referencing table expressions below the aggregation are
-        # invalid.
-        pass
-
-    def test_projection_with_star_expr(self):
-        new_expr = (self.table['a'] * 5).name('bigger_a')
-
-        t = self.table
-
-        # it lives!
-        proj = t[t, new_expr]
-        repr(proj)
-
-        ex_names = self.table.schema().names + ['bigger_a']
-        assert proj.schema().names == ex_names
-
-        # cannot pass an invalid table expression
-        t2 = t.aggregate([t['a'].sum().name('sum(a)')], by=['g'])
-        self.assertRaises(RelationError, t.__getitem__, [t2])
-
-        # TODO: there may be some ways this can be invalid
-
-    def test_projection_convenient_syntax(self):
-        proj = self.table[self.table, self.table['a'].name('foo')]
-        proj2 = self.table[[self.table, self.table['a'].name('foo')]]
-        assert_equal(proj, proj2)
-
-    def test_projection_mutate_analysis_bug(self):
-        # GH #549
-
-        t = self.con.table('airlines')
-
-        filtered = t[t.depdelay.notnull()]
-        leg = ibis.literal('-').join([t.origin, t.dest])
-        mutated = filtered.mutate(leg=leg)
-
-        # it works!
-        mutated['year', 'month', 'day', 'depdelay', 'leg']
-
-    def test_projection_self(self):
-        result = self.table[self.table]
-        expected = self.table.projection(self.table)
-
-        assert_equal(result, expected)
-
-    def test_projection_array_expr(self):
-        result = self.table[self.table.a]
-        expected = self.table[[self.table.a]]
-        assert_equal(result, expected)
-
-    def test_add_column(self):
-        # Creates a projection with a select-all on top of a non-projection
-        # TableExpr
-        new_expr = (self.table['a'] * 5).name('bigger_a')
-
-        t = self.table
-
-        result = t.add_column(new_expr)
-        expected = t[[t, new_expr]]
-        assert_equal(result, expected)
-
-        result = t.add_column(new_expr, 'wat')
-        expected = t[[t, new_expr.name('wat')]]
-        assert_equal(result, expected)
-
-    def test_add_column_scalar_expr(self):
-        # Check literals, at least
-        pass
-
-    def test_add_column_aggregate_crossjoin(self):
-        # A new column that depends on a scalar value produced by this or some
-        # other table.
-        #
-        # For example:
-        # SELECT *, b - VAL
-        # FROM table1
-        #
-        # Here, VAL could be something produced by aggregating table1 or any
-        # other table for that matter.
-        pass
-
-    def test_add_column_existing_projection(self):
-        # The "blocking" predecessor table is a projection; we can simply add
-        # the column to the existing projection
-        foo = (self.table.f * 2).name('foo')
-        bar = (self.table.f * 4).name('bar')
-        t2 = self.table.add_column(foo)
-        t3 = t2.add_column(bar)
-
-        expected = self.table[self.table, foo, bar]
-        assert_equal(t3, expected)
-
-    def test_mutate(self):
-        one = self.table.f * 2
-        foo = (self.table.a + self.table.b).name('foo')
-
-        expr = self.table.mutate(foo, one=one, two=2)
-        expected = self.table[self.table, foo, one.name('one'),
-                              ibis.literal(2).name('two')]
-        assert_equal(expr, expected)
-
-    def test_mutate_alter_existing_columns(self):
-        new_f = self.table.f * 2
-        foo = self.table.d * 2
-        expr = self.table.mutate(f=new_f, foo=foo)
-
-        expected = self.table['a', 'b', 'c', 'd', 'e',
-                              new_f.name('f'), 'g', 'h',
-                              foo.name('foo')]
-
-        assert_equal(expr, expected)
-
-    def test_replace_column(self):
-        tb = api.table([
-            ('a', 'int32'),
-            ('b', 'double'),
-            ('c', 'string')
-        ])
-
-        expr = tb.b.cast('int32')
-        tb2 = tb.set_column('b', expr)
-        expected = tb[tb.a, expr.name('b'), tb.c]
-
-        assert_equal(tb2, expected)
-
-    def test_filter_no_list(self):
-        pred = self.table.a > 5
-
-        result = self.table.filter(pred)
-        expected = self.table[pred]
-        assert_equal(result, expected)
-
-    def test_add_predicate(self):
-        pred = self.table['a'] > 5
-        result = self.table[pred]
-        assert isinstance(result.op(), ops.Selection)
-
-    def test_invalid_predicate(self):
-        # a lookalike
-        table2 = api.table(self.schema, name='bar')
-        self.assertRaises(RelationError, self.table.__getitem__,
-                          table2['a'] > 5)
-
-    def test_add_predicate_coalesce(self):
-        # Successive predicates get combined into one rather than nesting. This
-        # is mainly to enhance readability since we could handle this during
-        # expression evaluation anyway.
-        pred1 = self.table['a'] > 5
-        pred2 = self.table['b'] > 0
-
-        result = self.table[pred1][pred2]
-        expected = self.table.filter([pred1, pred2])
-        assert_equal(result, expected)
-
-        # 59, if we are not careful, we can obtain broken refs
-        interm = self.table[pred1]
-        result = interm.filter([interm['b'] > 0])
-        assert_equal(result, expected)
-
-    def test_repr_same_but_distinct_objects(self):
-        t = self.con.table('test1')
-        t_copy = self.con.table('test1')
-        table2 = t[t_copy['f'] > 0]
-
-        result = repr(table2)
-        assert result.count('DatabaseTable') == 1
-
-    def test_filter_fusion_distinct_table_objects(self):
-        t = self.con.table('test1')
-        tt = self.con.table('test1')
-
-        expr = t[t.f > 0][t.c > 0]
-        expr2 = t[t.f > 0][tt.c > 0]
-        expr3 = t[tt.f > 0][tt.c > 0]
-        expr4 = t[tt.f > 0][t.c > 0]
-
-        assert_equal(expr, expr2)
-        assert repr(expr) == repr(expr2)
-        assert_equal(expr, expr3)
-        assert_equal(expr, expr4)
-
-    def test_column_relabel(self):
-        # GH #551. Keeping the test case very high level to not presume that
-        # the relabel is necessarily implemented using a projection
-        types = ['int32', 'string', 'double']
-        table = api.table(zip(['foo', 'bar', 'baz'], types))
-        result = table.relabel({'foo': 'one', 'baz': 'three'})
-
-        schema = result.schema()
-        ex_schema = api.schema(zip(['one', 'bar', 'three'], types))
-        assert_equal(schema, ex_schema)
-
-    def test_limit(self):
-        limited = self.table.limit(10, offset=5)
-        assert limited.op().n == 10
-        assert limited.op().offset == 5
-
-    def test_sort_by(self):
-        # Commit to some API for ascending and descending
-        #
-        # table.sort_by(['g', expr1, desc(expr2), desc(expr3)])
-        #
-        # Default is ascending for anything coercable to an expression,
-        # and we'll have ascending/descending wrappers to help.
-        result = self.table.sort_by(['f'])
-
-        sort_key = result.op().sort_keys[0].op()
-
-        assert_equal(sort_key.expr, self.table.f)
-        assert sort_key.ascending
-
-        # non-list input. per #150
-        result2 = self.table.sort_by('f')
-        assert_equal(result, result2)
-
-        result2 = self.table.sort_by([('f', False)])
-        result3 = self.table.sort_by([('f', 'descending')])
-        result4 = self.table.sort_by([('f', 0)])
-
-        key2 = result2.op().sort_keys[0].op()
-        key3 = result3.op().sort_keys[0].op()
-        key4 = result4.op().sort_keys[0].op()
-
-        assert not key2.ascending
-        assert not key3.ascending
-        assert not key4.ascending
-        assert_equal(result2, result3)
-
-    def test_sort_by_desc_deferred_sort_key(self):
-        result = (self.table.group_by('g')
-                  .size()
-                  .sort_by(ibis.desc('count')))
-
-        tmp = self.table.group_by('g').size()
-        expected = tmp.sort_by((tmp['count'], False))
-        expected2 = tmp.sort_by(ibis.desc(tmp['count']))
-
-        assert_equal(result, expected)
-        assert_equal(result, expected2)
-
-    def test_slice_convenience(self):
-        expr = self.table[:5]
-        expr2 = self.table[:5:1]
-        assert_equal(expr, self.table.limit(5))
-        assert_equal(expr, expr2)
-
-        expr = self.table[2:7]
-        expr2 = self.table[2:7:1]
-        assert_equal(expr, self.table.limit(5, offset=2))
-        assert_equal(expr, expr2)
-
-        self.assertRaises(ValueError, self.table.__getitem__, slice(2, 15, 2))
-        self.assertRaises(ValueError, self.table.__getitem__, slice(5, None))
-        self.assertRaises(ValueError, self.table.__getitem__, slice(None, -5))
-        self.assertRaises(ValueError, self.table.__getitem__, slice(-10, -5))
-
-
-class TestAggregation(BasicTestCase, unittest.TestCase):
-
-    def test_count(self):
-        result = self.table['a'].count()
-        assert isinstance(result, api.Int64Scalar)
-        assert isinstance(result.op(), ops.Count)
-
-    def test_table_count(self):
-        result = self.table.count()
-        assert isinstance(result, api.Int64Scalar)
-        assert isinstance(result.op(), ops.Count)
-        assert result.get_name() == 'count'
-
-    def test_len_raises_expression_error(self):
-        with self.assertRaises(com.ExpressionError):
-            len(self.table)
-
-    def test_sum_expr_basics(self):
-        # Impala gives bigint for all integer types
-        ex_class = api.Int64Scalar
-        for c in self.int_cols + self.bool_cols:
-            result = self.table[c].sum()
-            assert isinstance(result, ex_class)
-            assert isinstance(result.op(), ops.Sum)
-
-        # Impala gives double for all floating point types
-        ex_class = api.DoubleScalar
-        for c in self.float_cols:
-            result = self.table[c].sum()
-            assert isinstance(result, ex_class)
-            assert isinstance(result.op(), ops.Sum)
-
-    def test_mean_expr_basics(self):
-        cols = self.int_cols + self.float_cols + self.bool_cols
-        for c in cols:
-            result = self.table[c].mean()
-            assert isinstance(result, api.DoubleScalar)
-            assert isinstance(result.op(), ops.Mean)
-
-    def test_aggregate_no_keys(self):
-        agg_exprs = [self.table['a'].sum().name('sum(a)'),
-                     self.table['c'].mean().name('mean(c)')]
-
-        # A TableExpr, which in SQL at least will yield a table with a single
-        # row
-        result = self.table.aggregate(agg_exprs)
-        assert isinstance(result, TableExpr)
-
-    def test_aggregate_keys_basic(self):
-        agg_exprs = [self.table['a'].sum().name('sum(a)'),
-                     self.table['c'].mean().name('mean(c)')]
-
-        # A TableExpr, which in SQL at least will yield a table with a single
-        # row
-        result = self.table.aggregate(agg_exprs, by=['g'])
-        assert isinstance(result, TableExpr)
-
-        # it works!
-        repr(result)
-
-    def test_aggregate_non_list_inputs(self):
-        # per #150
-        metric = self.table.f.sum().name('total')
-        by = 'g'
-        having = self.table.c.sum() > 10
-
-        result = self.table.aggregate(metric, by=by, having=having)
-        expected = self.table.aggregate([metric], by=[by], having=[having])
-        assert_equal(result, expected)
-
-    def test_aggregate_keywords(self):
-        t = self.table
-
-        expr = t.aggregate(foo=t.f.sum(), bar=lambda x: x.f.mean(),
-                           by='g')
-        expr2 = t.group_by('g').aggregate(foo=t.f.sum(),
-                                          bar=lambda x: x.f.mean())
-        expected = t.aggregate([t.f.mean().name('bar'),
-                                t.f.sum().name('foo')], by='g')
-
-        assert_equal(expr, expected)
-        assert_equal(expr2, expected)
-
-    def test_groupby_alias(self):
-        t = self.table
-
-        result = t.groupby('g').size()
-        expected = t.group_by('g').size()
-        assert_equal(result, expected)
-
-    def test_summary_expand_list(self):
-        summ = self.table.f.summary()
-
-        metric = self.table.g.group_concat().name('bar')
-        result = self.table.aggregate([metric, summ])
-        expected = self.table.aggregate([metric] + summ.exprs())
-        assert_equal(result, expected)
-
-    def test_aggregate_invalid(self):
-        # Pass a non-aggregation or non-scalar expr
-        pass
-
-    def test_filter_aggregate_pushdown_predicate(self):
-        # In the case where we want to add a predicate to an aggregate
-        # expression after the fact, rather than having to backpedal and add it
-        # before calling aggregate.
-        #
-        # TODO (design decision): This could happen automatically when adding a
-        # predicate originating from the same root table; if an expression is
-        # created from field references from the aggregated table then it
-        # becomes a filter predicate applied on top of a view
-
-        pred = self.table.f > 0
-        metrics = [self.table.a.sum().name('total')]
-        agged = self.table.aggregate(metrics, by=['g'])
-        filtered = agged.filter([pred])
-        expected = self.table[pred].aggregate(metrics, by=['g'])
-        assert_equal(filtered, expected)
-
-    def test_filter_aggregate_partial_pushdown(self):
-        pass
-
-    def test_aggregate_post_predicate(self):
-        # Test invalid having clause
-        metrics = [self.table.f.sum().name('total')]
-        by = ['g']
-
-        invalid_having_cases = [
-            self.table.f.sum(),
-            self.table.f > 2
-        ]
-        for case in invalid_having_cases:
-            self.assertRaises(com.ExpressionError, self.table.aggregate,
-                              metrics, by=by, having=[case])
-
-    def test_group_by_having_api(self):
-        # #154, add a HAVING post-predicate in a composable way
-        metric = self.table.f.sum().name('foo')
-        postp = self.table.d.mean() > 1
-
-        expr = (self.table
-                .group_by('g')
-                .having(postp)
-                .aggregate(metric))
-
-        expected = self.table.aggregate(metric, by='g', having=postp)
-        assert_equal(expr, expected)
-
-    def test_group_by_kwargs(self):
-        t = self.table
-        expr = (t.group_by(['f', t.h], z='g', z2=t.d)
-                 .aggregate(t.d.mean().name('foo')))
-        expected = (t.group_by(['f', t.h, t.g.name('z'), t.d.name('z2')])
-                    .aggregate(t.d.mean().name('foo')))
-        assert_equal(expr, expected)
-
-    def test_aggregate_root_table_internal(self):
-        pass
-
-    def test_compound_aggregate_expr(self):
-        # See ibis #24
-        compound_expr = (self.table['a'].sum() /
-                         self.table['a'].mean()).name('foo')
-        assert ops.is_reduction(compound_expr)
-
-        # Validates internally
-        self.table.aggregate([compound_expr])
-
-    def test_groupby_convenience(self):
-        metrics = [self.table.f.sum().name('total')]
-
-        expr = self.table.group_by('g').aggregate(metrics)
-        expected = self.table.aggregate(metrics, by=['g'])
-        assert_equal(expr, expected)
-
-        group_expr = self.table.g.cast('double').name('g')
-        expr = self.table.group_by(group_expr).aggregate(metrics)
-        expected = self.table.aggregate(metrics, by=[group_expr])
-        assert_equal(expr, expected)
-
-    def test_group_by_count_size(self):
-        # #148, convenience for interactive use, and so forth
-        result1 = self.table.group_by('g').size()
-        result2 = self.table.group_by('g').count()
-
-        expected = (self.table.group_by('g')
-                    .aggregate([self.table.count().name('count')]))
-
-        assert_equal(result1, expected)
-        assert_equal(result2, expected)
-
-        result = self.table.group_by('g').count('foo')
-        expected = (self.table.group_by('g')
-                    .aggregate([self.table.count().name('foo')]))
-        assert_equal(result, expected)
-
-    def test_group_by_column_select_api(self):
-        grouped = self.table.group_by('g')
-
-        result = grouped.f.sum()
-        expected = grouped.aggregate(self.table.f.sum().name('sum(f)'))
-        assert_equal(result, expected)
-
-        supported_functions = ['sum', 'mean', 'count', 'size', 'max', 'min']
-
-        # make sure they all work
-        for fn in supported_functions:
-            getattr(grouped.f, fn)()
-
-    def test_value_counts_convenience(self):
-        # #152
-        result = self.table.g.value_counts()
-        expected = (self.table.group_by('g')
-                    .aggregate(self.table.count().name('count')))
-
-        assert_equal(result, expected)
-
-    def test_isin_value_counts(self):
-        # #157, this code path was untested before
-        bool_clause = self.table.g.notin(['1', '4', '7'])
-        # it works!
-        bool_clause.name('notin').value_counts()
-
-    def test_value_counts_unnamed_expr(self):
-        nation = self.con.table('tpch_nation')
-
-        expr = nation.n_name.lower().value_counts()
-        expected = nation.n_name.lower().name('unnamed').value_counts()
-        assert_equal(expr, expected)
-
-    def test_aggregate_unnamed_expr(self):
-        nation = self.con.table('tpch_nation')
-        expr = nation.n_name.lower().left(1)
-        self.assertRaises(com.ExpressionError, nation.group_by(expr).aggregate,
-                          nation.count().name('metric'))
-
-    def test_default_reduction_names(self):
-        d = self.table.f
-        cases = [
-            (d.count(), 'count'),
-            (d.sum(), 'sum'),
-            (d.mean(), 'mean'),
-            (d.approx_nunique(), 'approx_nunique'),
-            (d.approx_median(), 'approx_median'),
-            (d.min(), 'min'),
-            (d.max(), 'max')
-        ]
-
-        for expr, ex_name in cases:
-            assert expr.get_name() == ex_name
-
-
-class TestJoinsUnions(BasicTestCase, unittest.TestCase):
-
-    def test_join_no_predicate_list(self):
-        region = self.con.table('tpch_region')
-        nation = self.con.table('tpch_nation')
-
-        pred = region.r_regionkey == nation.n_regionkey
-        joined = region.inner_join(nation, pred)
-        expected = region.inner_join(nation, [pred])
-        assert_equal(joined, expected)
-
-    def test_equijoin_schema_merge(self):
-        table1 = ibis.table([('key1',  'string'), ('value1', 'double')])
-        table2 = ibis.table([('key2',  'string'), ('stuff', 'int32')])
-
-        pred = table1['key1'] == table2['key2']
-        join_types = ['inner_join', 'left_join', 'outer_join']
-
-        ex_schema = api.Schema(['key1', 'value1', 'key2', 'stuff'],
-                               ['string', 'double', 'string', 'int32'])
-
-        for fname in join_types:
-            f = getattr(table1, fname)
-            joined = f(table2, [pred]).materialize()
-            assert_equal(joined.schema(), ex_schema)
-
-    def test_join_combo_with_projection(self):
-        # Test a case where there is column name overlap, but the projection
-        # passed makes it a non-issue. Highly relevant with self-joins
-        #
-        # For example, where left/right have some field names in common:
-        # SELECT left.*, right.a, right.b
-        # FROM left join right on left.key = right.key
-        t = self.table
-        t2 = t.add_column(t['f'] * 2, 'foo')
-        t2 = t2.add_column(t['f'] * 4, 'bar')
-
-        # this works
-        joined = t.left_join(t2, [t['g'] == t2['g']])
-        proj = joined.projection([t, t2['foo'], t2['bar']])
-        repr(proj)
-
-    def test_join_getitem_projection(self):
-        region = self.con.table('tpch_region')
-        nation = self.con.table('tpch_nation')
-
-        pred = region.r_regionkey == nation.n_regionkey
-        joined = region.inner_join(nation, pred)
-
-        result = joined[nation]
-        expected = joined.projection(nation)
-        assert_equal(result, expected)
-
-    def test_self_join(self):
-        # Self-joins are problematic with this design because column
-        # expressions may reference either the left or right self. For example:
-        #
-        # SELECT left.key, sum(left.value - right.value) as total_deltas
-        # FROM table left
-        #  INNER JOIN table right
-        #    ON left.current_period = right.previous_period + 1
-        # GROUP BY 1
-        #
-        # One way around the self-join issue is to force the user to add
-        # prefixes to the joined fields, then project using those. Not that
-        # satisfying, though.
-        left = self.table
-        right = self.table.view()
-        metric = (left['a'] - right['b']).mean().name('metric')
-
-        joined = left.inner_join(right, [right['g'] == left['g']])
-        # basic check there's no referential problems
-        result_repr = repr(joined)
-        assert 'ref_0' in result_repr
-        assert 'ref_1' in result_repr
-
-        # Cannot be immediately materialized because of the schema overlap
-        self.assertRaises(RelationError, joined.materialize)
-
-        # Project out left table schema
-        proj = joined[[left]]
-        assert_equal(proj.schema(), left.schema())
-
-        # Try aggregating on top of joined
-        aggregated = joined.aggregate([metric], by=[left['g']])
-        ex_schema = api.Schema(['g', 'metric'], ['string', 'double'])
-        assert_equal(aggregated.schema(), ex_schema)
-
-    def test_self_join_no_view_convenience(self):
-        # #165, self joins ought to be possible when the user specifies the
-        # column names to join on rather than referentially-valid expressions
-
-        result = self.table.join(self.table, [('g', 'g')])
-
-        t2 = self.table.view()
-        expected = self.table.join(t2, self.table.g == t2.g)
-        assert_equal(result, expected)
-
-    def test_materialized_join_reference_bug(self):
-        # GH#403
-        orders = self.con.table('tpch_orders')
-        customer = self.con.table('tpch_customer')
-        lineitem = self.con.table('tpch_lineitem')
-
-        items = (orders
-                 .join(lineitem, orders.o_orderkey == lineitem.l_orderkey)
-                 [lineitem, orders.o_custkey, orders.o_orderpriority]
-                 .join(customer, [('o_custkey', 'c_custkey')])
-                 .materialize())
-        items['o_orderpriority'].value_counts()
-
-    def test_join_project_after(self):
-        # e.g.
-        #
-        # SELECT L.foo, L.bar, R.baz, R.qux
-        # FROM table1 L
-        #   INNER JOIN table2 R
-        #     ON L.key = R.key
-        #
-        # or
-        #
-        # SELECT L.*, R.baz
-        # ...
-        #
-        # The default for a join is selecting all fields if possible
-        table1 = ibis.table([('key1',  'string'), ('value1', 'double')])
-        table2 = ibis.table([('key2',  'string'), ('stuff', 'int32')])
-
-        pred = table1['key1'] == table2['key2']
-
-        joined = table1.left_join(table2, [pred])
-        projected = joined.projection([table1, table2['stuff']])
-        assert projected.schema().names == ['key1', 'value1', 'stuff']
-
-        projected = joined.projection([table2, table1['key1']])
-        assert projected.schema().names == ['key2', 'stuff', 'key1']
-
-    def test_semi_join_schema(self):
-        # A left semi join discards the schema of the right table
-        table1 = ibis.table([('key1',  'string'), ('value1', 'double')])
-        table2 = ibis.table([('key2',  'string'), ('stuff', 'double')])
-
-        pred = table1['key1'] == table2['key2']
-        semi_joined = table1.semi_join(table2, [pred]).materialize()
-
-        result_schema = semi_joined.schema()
-        assert_equal(result_schema, table1.schema())
-
-    def test_cross_join(self):
-        agg_exprs = [self.table['a'].sum().name('sum_a'),
-                     self.table['b'].mean().name('mean_b')]
-        scalar_aggs = self.table.aggregate(agg_exprs)
-
-        joined = self.table.cross_join(scalar_aggs).materialize()
-        agg_schema = api.Schema(['sum_a', 'mean_b'], ['int64', 'double'])
-        ex_schema = self.table.schema().append(agg_schema)
+def test_empty_schema():
+    table = api.table([], 'foo')
+    assert len(table.schema()) == 0
+
+
+def test_columns(con):
+    t = con.table('alltypes')
+    result = t.columns
+    expected = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
+    assert result == expected
+
+
+def test_view_new_relation(table):
+    # For assisting with self-joins and other self-referential operations
+    # where we need to be able to treat instances of the same TableExpr as
+    # semantically distinct
+    #
+    # This thing is not exactly a projection, since it has no semantic
+    # meaning when it comes to execution
+    tview = table.view()
+
+    roots = tview._root_tables()
+    assert len(roots) == 1
+    assert roots[0] is tview.op()
+
+
+def test_get_type(table, schema_dict):
+    for k, v in schema_dict.items():
+        assert table._get_type(k) == v
+
+
+def test_getitem_column_select(table, schema_dict):
+    for k, v in schema_dict.items():
+        col = table[k]
+
+        # Make sure it's the right type
+        assert isinstance(col, ArrayExpr)
+        assert isinstance(col, array_type(v))
+
+        # Ensure we have a field selection with back-reference to the table
+        parent = col.parent()
+        assert isinstance(parent, ops.TableColumn)
+        assert parent.parent() is table
+
+
+def test_getitem_attribute(table):
+    result = table.a
+    assert_equal(result, table['a'])
+
+    assert 'a' in dir(table)
+
+    # Project and add a name that conflicts with a TableExpr built-in
+    # attribute
+    view = table[[table, table['a'].name('schema')]]
+    assert not isinstance(view.schema, ArrayExpr)
+
+
+def test_projection(table):
+    cols = ['f', 'a', 'h']
+
+    proj = table[cols]
+    assert isinstance(proj, TableExpr)
+    assert isinstance(proj.op(), ops.Selection)
+
+    assert proj.schema().names == cols
+    for c in cols:
+        expr = proj[c]
+        assert isinstance(expr, type(table[c]))
+
+
+def test_projection_no_list(table):
+    expr = (table.f * 2).name('bar')
+    result = table.select(expr)
+    expected = table.projection([expr])
+    assert_equal(result, expected)
+
+
+def test_projection_with_exprs(table):
+    # unnamed expr to test
+    mean_diff = (table['a'] - table['c']).mean()
+
+    col_exprs = [table['b'].log().name('log_b'),
+                 mean_diff.name('mean_diff')]
+
+    proj = table[col_exprs + ['g']]
+    schema = proj.schema()
+    assert schema.names == ['log_b', 'mean_diff', 'g']
+    assert schema.types == ['double', 'double', 'string']
+
+    # Test with unnamed expr
+    with pytest.raises(ExpressionError):
+        table.projection(['g', table['a'] - table['c']])
+
+
+def test_projection_duplicate_names(table):
+    with pytest.raises(com.IntegrityError):
+        table.projection([table.c, table.c])
+
+
+def test_projection_invalid_root(table):
+    schema1 = {
+        'foo': 'double',
+        'bar': 'int32'
+    }
+
+    left = api.table(schema1, name='foo')
+    right = api.table(schema1, name='bar')
+
+    exprs = [right['foo'], right['bar']]
+    with pytest.raises(RelationError):
+        left.projection(exprs)
+
+
+def test_projection_unnamed_literal_interactive_blowup(con):
+    # #147 and #153 alike
+    table = con.table('functional_alltypes')
+
+    with config.option_context('interactive', True):
+        try:
+            table.select([table.bigint_col, ibis.literal(5)])
+        except Exception as e:
+            assert 'named' in e.args[0]
+
+
+def test_projection_of_aggregated(table):
+    # Fully-formed aggregations "block"; in a projection, column
+    # expressions referencing table expressions below the aggregation are
+    # invalid.
+    pass
+
+
+def test_projection_with_star_expr(table):
+    new_expr = (table['a'] * 5).name('bigger_a')
+
+    t = table
+
+    # it lives!
+    proj = t[t, new_expr]
+    repr(proj)
+
+    ex_names = table.schema().names + ['bigger_a']
+    assert proj.schema().names == ex_names
+
+    # cannot pass an invalid table expression
+    t2 = t.aggregate([t['a'].sum().name('sum(a)')], by=['g'])
+    with pytest.raises(RelationError):
+        t[[t2]]
+    # TODO: there may be some ways this can be invalid
+
+
+def test_projection_convenient_syntax(table):
+    proj = table[table, table['a'].name('foo')]
+    proj2 = table[[table, table['a'].name('foo')]]
+    assert_equal(proj, proj2)
+
+
+def test_projection_mutate_analysis_bug(con):
+    # GH #549
+
+    t = con.table('airlines')
+
+    filtered = t[t.depdelay.notnull()]
+    leg = ibis.literal('-').join([t.origin, t.dest])
+    mutated = filtered.mutate(leg=leg)
+
+    # it works!
+    mutated['year', 'month', 'day', 'depdelay', 'leg']
+
+
+def test_projection_self(table):
+    result = table[table]
+    expected = table.projection(table)
+
+    assert_equal(result, expected)
+
+
+def test_projection_array_expr(table):
+    result = table[table.a]
+    expected = table[[table.a]]
+    assert_equal(result, expected)
+
+
+def test_add_column(table):
+    # Creates a projection with a select-all on top of a non-projection
+    # TableExpr
+    new_expr = (table['a'] * 5).name('bigger_a')
+
+    t = table
+
+    result = t.add_column(new_expr)
+    expected = t[[t, new_expr]]
+    assert_equal(result, expected)
+
+    result = t.add_column(new_expr, 'wat')
+    expected = t[[t, new_expr.name('wat')]]
+    assert_equal(result, expected)
+
+
+def test_add_column_scalar_expr(table):
+    # Check literals, at least
+    pass
+
+
+def test_add_column_aggregate_crossjoin(table):
+    # A new column that depends on a scalar value produced by this or some
+    # other table.
+    #
+    # For example:
+    # SELECT *, b - VAL
+    # FROM table1
+    #
+    # Here, VAL could be something produced by aggregating table1 or any
+    # other table for that matter.
+    pass
+
+
+def test_add_column_existing_projection(table):
+    # The "blocking" predecessor table is a projection; we can simply add
+    # the column to the existing projection
+    foo = (table.f * 2).name('foo')
+    bar = (table.f * 4).name('bar')
+    t2 = table.add_column(foo)
+    t3 = t2.add_column(bar)
+
+    expected = table[table, foo, bar]
+    assert_equal(t3, expected)
+
+
+def test_mutate(table):
+    one = table.f * 2
+    foo = (table.a + table.b).name('foo')
+
+    expr = table.mutate(foo, one=one, two=2)
+    expected = table[table, foo, one.name('one'),
+                          ibis.literal(2).name('two')]
+    assert_equal(expr, expected)
+
+
+def test_mutate_alter_existing_columns(table):
+    new_f = table.f * 2
+    foo = table.d * 2
+    expr = table.mutate(f=new_f, foo=foo)
+
+    expected = table['a', 'b', 'c', 'd', 'e',
+                          new_f.name('f'), 'g', 'h',
+                          foo.name('foo')]
+
+    assert_equal(expr, expected)
+
+
+def test_replace_column(table):
+    tb = api.table([
+        ('a', 'int32'),
+        ('b', 'double'),
+        ('c', 'string')
+    ])
+
+    expr = tb.b.cast('int32')
+    tb2 = tb.set_column('b', expr)
+    expected = tb[tb.a, expr.name('b'), tb.c]
+
+    assert_equal(tb2, expected)
+
+
+def test_filter_no_list(table):
+    pred = table.a > 5
+
+    result = table.filter(pred)
+    expected = table[pred]
+    assert_equal(result, expected)
+
+
+def test_add_predicate(table):
+    pred = table['a'] > 5
+    result = table[pred]
+    assert isinstance(result.op(), ops.Selection)
+
+
+def test_invalid_predicate(table, schema):
+    # a lookalike
+    table2 = api.table(schema, name='bar')
+    with pytest.raises(RelationError):
+        table[table2.a > 5]
+
+
+def test_add_predicate_coalesce(table):
+    # Successive predicates get combined into one rather than nesting. This
+    # is mainly to enhance readability since we could handle this during
+    # expression evaluation anyway.
+    pred1 = table['a'] > 5
+    pred2 = table['b'] > 0
+
+    result = table[pred1][pred2]
+    expected = table.filter([pred1, pred2])
+    assert_equal(result, expected)
+
+    # 59, if we are not careful, we can obtain broken refs
+    interm = table[pred1]
+    result = interm.filter([interm['b'] > 0])
+    assert_equal(result, expected)
+
+
+def test_repr_same_but_distinct_objects(con):
+    t = con.table('test1')
+    t_copy = con.table('test1')
+    table2 = t[t_copy['f'] > 0]
+
+    result = repr(table2)
+    assert result.count('DatabaseTable') == 1
+
+
+def test_filter_fusion_distinct_table_objects(con):
+    t = con.table('test1')
+    tt = con.table('test1')
+
+    expr = t[t.f > 0][t.c > 0]
+    expr2 = t[t.f > 0][tt.c > 0]
+    expr3 = t[tt.f > 0][tt.c > 0]
+    expr4 = t[tt.f > 0][t.c > 0]
+
+    assert_equal(expr, expr2)
+    assert repr(expr) == repr(expr2)
+    assert_equal(expr, expr3)
+    assert_equal(expr, expr4)
+
+
+def test_column_relabel(table):
+    # GH #551. Keeping the test case very high level to not presume that
+    # the relabel is necessarily implemented using a projection
+    types = ['int32', 'string', 'double']
+    table = api.table(zip(['foo', 'bar', 'baz'], types))
+    result = table.relabel({'foo': 'one', 'baz': 'three'})
+
+    schema = result.schema()
+    ex_schema = api.schema(zip(['one', 'bar', 'three'], types))
+    assert_equal(schema, ex_schema)
+
+
+def test_limit(table):
+    limited = table.limit(10, offset=5)
+    assert limited.op().n == 10
+    assert limited.op().offset == 5
+
+
+def test_sort_by(table):
+    # Commit to some API for ascending and descending
+    #
+    # table.sort_by(['g', expr1, desc(expr2), desc(expr3)])
+    #
+    # Default is ascending for anything coercable to an expression,
+    # and we'll have ascending/descending wrappers to help.
+    result = table.sort_by(['f'])
+
+    sort_key = result.op().sort_keys[0].op()
+
+    assert_equal(sort_key.expr, table.f)
+    assert sort_key.ascending
+
+    # non-list input. per #150
+    result2 = table.sort_by('f')
+    assert_equal(result, result2)
+
+    result2 = table.sort_by([('f', False)])
+    result3 = table.sort_by([('f', 'descending')])
+    result4 = table.sort_by([('f', 0)])
+
+    key2 = result2.op().sort_keys[0].op()
+    key3 = result3.op().sort_keys[0].op()
+    key4 = result4.op().sort_keys[0].op()
+
+    assert not key2.ascending
+    assert not key3.ascending
+    assert not key4.ascending
+    assert_equal(result2, result3)
+
+
+def test_sort_by_desc_deferred_sort_key(table):
+    result = (table.group_by('g')
+              .size()
+              .sort_by(ibis.desc('count')))
+
+    tmp = table.group_by('g').size()
+    expected = tmp.sort_by((tmp['count'], False))
+    expected2 = tmp.sort_by(ibis.desc(tmp['count']))
+
+    assert_equal(result, expected)
+    assert_equal(result, expected2)
+
+
+def test_slice_convenience(table):
+    expr = table[:5]
+    expr2 = table[:5:1]
+    assert_equal(expr, table.limit(5))
+    assert_equal(expr, expr2)
+
+    expr = table[2:7]
+    expr2 = table[2:7:1]
+    assert_equal(expr, table.limit(5, offset=2))
+    assert_equal(expr, expr2)
+
+    with pytest.raises(ValueError):
+        table[2:15:2]
+
+    with pytest.raises(ValueError):
+        table[5:]
+
+    with pytest.raises(ValueError):
+        table[:-5]
+
+    with pytest.raises(ValueError):
+        table[-10:-5]
+
+
+def test_table_count(table):
+    result = table.count()
+    assert isinstance(result, api.Int64Scalar)
+    assert isinstance(result.op(), ops.Count)
+    assert result.get_name() == 'count'
+
+
+def test_len_raises_expression_error(table):
+    with pytest.raises(com.ExpressionError):
+        len(table)
+
+
+def test_sum_expr_basics(table, int_col):
+    # Impala gives bigint for all integer types
+    ex_class = api.Int64Scalar
+    result = table[int_col].sum()
+    assert isinstance(result, api.Int64Scalar)
+    assert isinstance(result.op(), ops.Sum)
+
+
+def test_sum_expr_basics_floats(table, float_col):
+    # Impala gives double for all floating point types
+    ex_class = api.DoubleScalar
+    result = table[float_col].sum()
+    assert isinstance(result, api.DoubleScalar)
+    assert isinstance(result.op(), ops.Sum)
+
+
+def test_mean_expr_basics(table, numeric_col):
+    result = table[numeric_col].mean()
+    assert isinstance(result, api.DoubleScalar)
+    assert isinstance(result.op(), ops.Mean)
+
+
+def test_aggregate_no_keys(table):
+    agg_exprs = [table['a'].sum().name('sum(a)'),
+                 table['c'].mean().name('mean(c)')]
+
+    # A TableExpr, which in SQL at least will yield a table with a single
+    # row
+    result = table.aggregate(agg_exprs)
+    assert isinstance(result, TableExpr)
+
+
+def test_aggregate_keys_basic(table):
+    agg_exprs = [table['a'].sum().name('sum(a)'),
+                 table['c'].mean().name('mean(c)')]
+
+    # A TableExpr, which in SQL at least will yield a table with a single
+    # row
+    result = table.aggregate(agg_exprs, by=['g'])
+    assert isinstance(result, TableExpr)
+
+    # it works!
+    repr(result)
+
+
+def test_aggregate_non_list_inputs(table):
+    # per #150
+    metric = table.f.sum().name('total')
+    by = 'g'
+    having = table.c.sum() > 10
+
+    result = table.aggregate(metric, by=by, having=having)
+    expected = table.aggregate([metric], by=[by], having=[having])
+    assert_equal(result, expected)
+
+
+def test_aggregate_keywords(table):
+    t = table
+
+    expr = t.aggregate(foo=t.f.sum(), bar=lambda x: x.f.mean(),
+                       by='g')
+    expr2 = t.group_by('g').aggregate(foo=t.f.sum(),
+                                      bar=lambda x: x.f.mean())
+    expected = t.aggregate([t.f.mean().name('bar'),
+                            t.f.sum().name('foo')], by='g')
+
+    assert_equal(expr, expected)
+    assert_equal(expr2, expected)
+
+
+def test_groupby_alias(table):
+    t = table
+
+    result = t.groupby('g').size()
+    expected = t.group_by('g').size()
+    assert_equal(result, expected)
+
+
+def test_summary_expand_list(table):
+    summ = table.f.summary()
+
+    metric = table.g.group_concat().name('bar')
+    result = table.aggregate([metric, summ])
+    expected = table.aggregate([metric] + summ.exprs())
+    assert_equal(result, expected)
+
+
+def test_aggregate_invalid(table):
+    # Pass a non-aggregation or non-scalar expr
+    pass
+
+
+def test_filter_aggregate_pushdown_predicate(table):
+    # In the case where we want to add a predicate to an aggregate
+    # expression after the fact, rather than having to backpedal and add it
+    # before calling aggregate.
+    #
+    # TODO (design decision): This could happen automatically when adding a
+    # predicate originating from the same root table; if an expression is
+    # created from field references from the aggregated table then it
+    # becomes a filter predicate applied on top of a view
+
+    pred = table.f > 0
+    metrics = [table.a.sum().name('total')]
+    agged = table.aggregate(metrics, by=['g'])
+    filtered = agged.filter([pred])
+    expected = table[pred].aggregate(metrics, by=['g'])
+    assert_equal(filtered, expected)
+
+
+def test_filter_aggregate_partial_pushdown(table):
+    pass
+
+
+def test_aggregate_post_predicate(table):
+    # Test invalid having clause
+    metrics = [table.f.sum().name('total')]
+    by = ['g']
+
+    invalid_having_cases = [
+        table.f.sum(),
+        table.f > 2
+    ]
+    for case in invalid_having_cases:
+        with pytest.raises(com.ExpressionError):
+            table.aggregate(metrics, by=by, having=[case])
+
+
+def test_group_by_having_api(table):
+    # #154, add a HAVING post-predicate in a composable way
+    metric = table.f.sum().name('foo')
+    postp = table.d.mean() > 1
+
+    expr = (table
+            .group_by('g')
+            .having(postp)
+            .aggregate(metric))
+
+    expected = table.aggregate(metric, by='g', having=postp)
+    assert_equal(expr, expected)
+
+
+def test_group_by_kwargs(table):
+    t = table
+    expr = (t.group_by(['f', t.h], z='g', z2=t.d)
+             .aggregate(t.d.mean().name('foo')))
+    expected = (t.group_by(['f', t.h, t.g.name('z'), t.d.name('z2')])
+                .aggregate(t.d.mean().name('foo')))
+    assert_equal(expr, expected)
+
+
+def test_aggregate_root_table_internal(table):
+    pass
+
+
+def test_compound_aggregate_expr(table):
+    # See ibis #24
+    compound_expr = (table['a'].sum() /
+                     table['a'].mean()).name('foo')
+    assert ops.is_reduction(compound_expr)
+
+    # Validates internally
+    table.aggregate([compound_expr])
+
+
+def test_groupby_convenience(table):
+    metrics = [table.f.sum().name('total')]
+
+    expr = table.group_by('g').aggregate(metrics)
+    expected = table.aggregate(metrics, by=['g'])
+    assert_equal(expr, expected)
+
+    group_expr = table.g.cast('double').name('g')
+    expr = table.group_by(group_expr).aggregate(metrics)
+    expected = table.aggregate(metrics, by=[group_expr])
+    assert_equal(expr, expected)
+
+
+def test_group_by_count_size(table):
+    # #148, convenience for interactive use, and so forth
+    result1 = table.group_by('g').size()
+    result2 = table.group_by('g').count()
+
+    expected = (table.group_by('g')
+                .aggregate([table.count().name('count')]))
+
+    assert_equal(result1, expected)
+    assert_equal(result2, expected)
+
+    result = table.group_by('g').count('foo')
+    expected = (table.group_by('g')
+                .aggregate([table.count().name('foo')]))
+    assert_equal(result, expected)
+
+
+def test_group_by_column_select_api(table):
+    grouped = table.group_by('g')
+
+    result = grouped.f.sum()
+    expected = grouped.aggregate(table.f.sum().name('sum(f)'))
+    assert_equal(result, expected)
+
+    supported_functions = ['sum', 'mean', 'count', 'size', 'max', 'min']
+
+    # make sure they all work
+    for fn in supported_functions:
+        getattr(grouped.f, fn)()
+
+
+def test_value_counts_convenience(table):
+    # #152
+    result = table.g.value_counts()
+    expected = (table.group_by('g')
+                .aggregate(table.count().name('count')))
+
+    assert_equal(result, expected)
+
+
+def test_isin_value_counts(table):
+    # #157, this code path was untested before
+    bool_clause = table.g.notin(['1', '4', '7'])
+    # it works!
+    bool_clause.name('notin').value_counts()
+
+
+def test_value_counts_unnamed_expr(con):
+    nation = con.table('tpch_nation')
+
+    expr = nation.n_name.lower().value_counts()
+    expected = nation.n_name.lower().name('unnamed').value_counts()
+    assert_equal(expr, expected)
+
+
+def test_aggregate_unnamed_expr(con):
+    nation = con.table('tpch_nation')
+    expr = nation.n_name.lower().left(1)
+    with pytest.raises(com.ExpressionError):
+        nation.group_by(expr).aggregate(nation.count().name('metric'))
+
+
+def test_default_reduction_names(table):
+    d = table.f
+    cases = [
+        (d.count(), 'count'),
+        (d.sum(), 'sum'),
+        (d.mean(), 'mean'),
+        (d.approx_nunique(), 'approx_nunique'),
+        (d.approx_median(), 'approx_median'),
+        (d.min(), 'min'),
+        (d.max(), 'max')
+    ]
+
+    for expr, ex_name in cases:
+        assert expr.get_name() == ex_name
+
+
+def test_join_no_predicate_list(con):
+    region = con.table('tpch_region')
+    nation = con.table('tpch_nation')
+
+    pred = region.r_regionkey == nation.n_regionkey
+    joined = region.inner_join(nation, pred)
+    expected = region.inner_join(nation, [pred])
+    assert_equal(joined, expected)
+
+
+def test_equijoin_schema_merge():
+    table1 = ibis.table([('key1',  'string'), ('value1', 'double')])
+    table2 = ibis.table([('key2',  'string'), ('stuff', 'int32')])
+
+    pred = table1['key1'] == table2['key2']
+    join_types = ['inner_join', 'left_join', 'outer_join']
+
+    ex_schema = api.Schema(['key1', 'value1', 'key2', 'stuff'],
+                           ['string', 'double', 'string', 'int32'])
+
+    for fname in join_types:
+        f = getattr(table1, fname)
+        joined = f(table2, [pred]).materialize()
         assert_equal(joined.schema(), ex_schema)
 
-    def test_cross_join_multiple(self):
-        a = self.table['a', 'b', 'c']
-        b = self.table['d', 'e']
-        c = self.table['f', 'h']
 
-        joined = ibis.cross_join(a, b, c)
-        expected = a.cross_join(b.cross_join(c))
-        assert joined.equals(expected)
+def test_join_combo_with_projection(table):
+    # Test a case where there is column name overlap, but the projection
+    # passed makes it a non-issue. Highly relevant with self-joins
+    #
+    # For example, where left/right have some field names in common:
+    # SELECT left.*, right.a, right.b
+    # FROM left join right on left.key = right.key
+    t = table
+    t2 = t.add_column(t['f'] * 2, 'foo')
+    t2 = t2.add_column(t['f'] * 4, 'bar')
 
-    def test_join_compound_boolean_predicate(self):
-        # The user might have composed predicates through logical operations
-        pass
-
-    def test_filter_join_unmaterialized(self):
-        table1 = ibis.table({'key1': 'string', 'key2': 'string',
-                            'value1': 'double'})
-        table2 = ibis.table({'key3': 'string', 'value2': 'double'})
-
-        # It works!
-        joined = table1.inner_join(table2, [table1['key1'] == table2['key3']])
-        filtered = joined.filter([table1.value1 > 0])
-        repr(filtered)
-
-    def test_join_overlapping_column_names(self):
-        t1 = ibis.table([('foo', 'string'),
-                         ('bar', 'string'),
-                         ('value1', 'double')])
-        t2 = ibis.table([('foo', 'string'),
-                         ('bar', 'string'),
-                         ('value2', 'double')])
-
-        joined = t1.join(t2, 'foo')
-        expected = t1.join(t2, t1.foo == t2.foo)
-        assert_equal(joined, expected)
-
-        joined = t1.join(t2, ['foo', 'bar'])
-        expected = t1.join(t2, [t1.foo == t2.foo,
-                                t1.bar == t2.bar])
-        assert_equal(joined, expected)
-
-    def test_join_key_alternatives(self):
-        t1 = self.con.table('star1')
-        t2 = self.con.table('star2')
-
-        # Join with tuples
-        joined = t1.inner_join(t2, [('foo_id', 'foo_id')])
-        joined2 = t1.inner_join(t2, [(t1.foo_id, t2.foo_id)])
-
-        # Join with single expr
-        joined3 = t1.inner_join(t2, t1.foo_id == t2.foo_id)
-
-        expected = t1.inner_join(t2, [t1.foo_id == t2.foo_id])
-
-        assert_equal(joined, expected)
-        assert_equal(joined2, expected)
-        assert_equal(joined3, expected)
-
-        self.assertRaises(com.ExpressionError, t1.inner_join, t2,
-                          [('foo_id', 'foo_id', 'foo_id')])
-
-    def test_join_invalid_refs(self):
-        t1 = self.con.table('star1')
-        t2 = self.con.table('star2')
-        t3 = self.con.table('star3')
-
-        predicate = t1.bar_id == t3.bar_id
-        self.assertRaises(com.RelationError, t1.inner_join, t2, [predicate])
-
-    def test_join_non_boolean_expr(self):
-        t1 = self.con.table('star1')
-        t2 = self.con.table('star2')
-
-        # oops
-        predicate = t1.f * t2.value1
-        self.assertRaises(com.ExpressionError, t1.inner_join, t2, [predicate])
-
-    def test_unravel_compound_equijoin(self):
-        t1 = ibis.table([
-            ('key1', 'string'),
-            ('key2', 'string'),
-            ('key3', 'string'),
-            ('value1', 'double')
-        ], 'foo_table')
-
-        t2 = ibis.table([
-            ('key1', 'string'),
-            ('key2', 'string'),
-            ('key3', 'string'),
-            ('value2', 'double')
-        ], 'bar_table')
-
-        p1 = t1.key1 == t2.key1
-        p2 = t1.key2 == t2.key2
-        p3 = t1.key3 == t2.key3
-
-        joined = t1.inner_join(t2, [p1 & p2 & p3])
-        expected = t1.inner_join(t2, [p1, p2, p3])
-        assert_equal(joined, expected)
-
-    def test_join_add_prefixes(self):
-        pass
-
-    def test_join_nontrivial_exprs(self):
-        pass
-
-    def test_union(self):
-        schema1 = [
-            ('key', 'string'),
-            ('value', 'double')
-        ]
-        schema2 = [
-            ('key', 'string'),
-            ('key2', 'string'),
-            ('value', 'double')
-        ]
-        t1 = ibis.table(schema1, 'foo')
-        t2 = ibis.table(schema1, 'bar')
-        t3 = ibis.table(schema2, 'baz')
-
-        result = t1.union(t2)
-        assert isinstance(result.op(), ops.Union)
-        assert not result.op().distinct
-
-        result = t1.union(t2, distinct=True)
-        assert isinstance(result.op(), ops.Union)
-        assert result.op().distinct
-
-        self.assertRaises(ir.RelationError, t1.union, t3)
-
-    def test_column_ref_on_projection_rename(self):
-        region = self.con.table('tpch_region')
-        nation = self.con.table('tpch_nation')
-        customer = self.con.table('tpch_customer')
-
-        joined = (region.inner_join(
-            nation, [region.r_regionkey == nation.n_regionkey])
-            .inner_join(
-                customer, [customer.c_nationkey == nation.n_nationkey]))
-
-        proj_exprs = [customer, nation.n_name.name('nation'),
-                      region.r_name.name('region')]
-        joined = joined.projection(proj_exprs)
-
-        metrics = [joined.c_acctbal.sum().name('metric')]
-
-        # it works!
-        joined.aggregate(metrics, by=['region'])
+    # this works
+    joined = t.left_join(t2, [t['g'] == t2['g']])
+    proj = joined.projection([t, t2['foo'], t2['bar']])
+    repr(proj)
 
 
-class TestSemiAntiJoinPredicates(unittest.TestCase):
+def test_join_getitem_projection(con):
+    region = con.table('tpch_region')
+    nation = con.table('tpch_nation')
 
-    def setUp(self):
-        self.con = MockConnection()
+    pred = region.r_regionkey == nation.n_regionkey
+    joined = region.inner_join(nation, pred)
 
-        self.t1 = ibis.table([
-            ('key1', 'string'),
-            ('key2', 'string'),
-            ('value1', 'double')
-        ], 'foo')
-
-        self.t2 = ibis.table([
-            ('key1', 'string'),
-            ('key2', 'string')
-        ], 'bar')
-
-    def test_simple_existence_predicate(self):
-        cond = (self.t1.key1 == self.t2.key1).any()
-
-        assert isinstance(cond, ir.BooleanArray)
-        op = cond.op()
-        assert isinstance(op, ops.Any)
-
-        # it works!
-        expr = self.t1[cond]
-        assert isinstance(expr.op(), ops.Selection)
-
-    def test_cannot_use_existence_expression_in_join(self):
-        # Join predicates must consist only of comparisons
-        pass
-
-    def test_not_exists_predicate(self):
-        cond = -(self.t1.key1 == self.t2.key1).any()
-        assert isinstance(cond.op(), ops.NotAny)
+    result = joined[nation]
+    expected = joined.projection(nation)
+    assert_equal(result, expected)
 
 
-class TestLateBindingFunctions(BasicTestCase, unittest.TestCase):
+def test_self_join(table):
+    # Self-joins are problematic with this design because column
+    # expressions may reference either the left or right  For example:
+    #
+    # SELECT left.key, sum(left.value - right.value) as total_deltas
+    # FROM table left
+    #  INNER JOIN table right
+    #    ON left.current_period = right.previous_period + 1
+    # GROUP BY 1
+    #
+    # One way around the self-join issue is to force the user to add
+    # prefixes to the joined fields, then project using those. Not that
+    # satisfying, though.
+    left = table
+    right = table.view()
+    metric = (left['a'] - right['b']).mean().name('metric')
 
-    def test_aggregate_metrics(self):
-        functions = [lambda x: x.e.sum().name('esum'),
-                     lambda x: x.f.sum().name('fsum')]
-        exprs = [self.table.e.sum().name('esum'),
-                 self.table.f.sum().name('fsum')]
+    joined = left.inner_join(right, [right['g'] == left['g']])
+    # basic check there's no referential problems
+    result_repr = repr(joined)
+    assert 'ref_0' in result_repr
+    assert 'ref_1' in result_repr
 
-        result = self.table.aggregate(functions[0])
-        expected = self.table.aggregate(exprs[0])
-        assert_equal(result, expected)
+    # Cannot be immediately materialized because of the schema overlap
+    with pytest.raises(RelationError):
+        joined.materialize()
 
-        result = self.table.aggregate(functions)
-        expected = self.table.aggregate(exprs)
-        assert_equal(result, expected)
+    # Project out left table schema
+    proj = joined[[left]]
+    assert_equal(proj.schema(), left.schema())
 
-    def test_group_by_keys(self):
-        m = self.table.mutate(foo=self.table.f * 2,
-                              bar=self.table.e / 2)
+    # Try aggregating on top of joined
+    aggregated = joined.aggregate([metric], by=[left['g']])
+    ex_schema = api.Schema(['g', 'metric'], ['string', 'double'])
+    assert_equal(aggregated.schema(), ex_schema)
 
-        expr = m.group_by(lambda x: x.foo).size()
-        expected = m.group_by('foo').size()
-        assert_equal(expr, expected)
 
-        expr = m.group_by([lambda x: x.foo, lambda x: x.bar]).size()
-        expected = m.group_by(['foo', 'bar']).size()
-        assert_equal(expr, expected)
+def test_self_join_no_view_convenience(table):
+    # #165, self joins ought to be possible when the user specifies the
+    # column names to join on rather than referentially-valid expressions
 
-    def test_having(self):
-        m = self.table.mutate(foo=self.table.f * 2,
-                              bar=self.table.e / 2)
+    result = table.join(table, [('g', 'g')])
 
-        expr = (m.group_by('foo')
-                .having(lambda x: x.foo.sum() > 10)
+    t2 = table.view()
+    expected = table.join(t2, table.g == t2.g)
+    assert_equal(result, expected)
+
+
+def test_materialized_join_reference_bug(con):
+    # GH#403
+    orders = con.table('tpch_orders')
+    customer = con.table('tpch_customer')
+    lineitem = con.table('tpch_lineitem')
+
+    items = (orders
+             .join(lineitem, orders.o_orderkey == lineitem.l_orderkey)
+             [lineitem, orders.o_custkey, orders.o_orderpriority]
+             .join(customer, [('o_custkey', 'c_custkey')])
+             .materialize())
+    items['o_orderpriority'].value_counts()
+
+
+def test_join_project_after(table):
+    # e.g.
+    #
+    # SELECT L.foo, L.bar, R.baz, R.qux
+    # FROM table1 L
+    #   INNER JOIN table2 R
+    #     ON L.key = R.key
+    #
+    # or
+    #
+    # SELECT L.*, R.baz
+    # ...
+    #
+    # The default for a join is selecting all fields if possible
+    table1 = ibis.table([('key1',  'string'), ('value1', 'double')])
+    table2 = ibis.table([('key2',  'string'), ('stuff', 'int32')])
+
+    pred = table1['key1'] == table2['key2']
+
+    joined = table1.left_join(table2, [pred])
+    projected = joined.projection([table1, table2['stuff']])
+    assert projected.schema().names == ['key1', 'value1', 'stuff']
+
+    projected = joined.projection([table2, table1['key1']])
+    assert projected.schema().names == ['key2', 'stuff', 'key1']
+
+
+def test_semi_join_schema(table):
+    # A left semi join discards the schema of the right table
+    table1 = ibis.table([('key1',  'string'), ('value1', 'double')])
+    table2 = ibis.table([('key2',  'string'), ('stuff', 'double')])
+
+    pred = table1['key1'] == table2['key2']
+    semi_joined = table1.semi_join(table2, [pred]).materialize()
+
+    result_schema = semi_joined.schema()
+    assert_equal(result_schema, table1.schema())
+
+
+def test_cross_join(table):
+    agg_exprs = [table['a'].sum().name('sum_a'),
+                 table['b'].mean().name('mean_b')]
+    scalar_aggs = table.aggregate(agg_exprs)
+
+    joined = table.cross_join(scalar_aggs).materialize()
+    agg_schema = api.Schema(['sum_a', 'mean_b'], ['int64', 'double'])
+    ex_schema = table.schema().append(agg_schema)
+    assert_equal(joined.schema(), ex_schema)
+
+
+def test_cross_join_multiple(table):
+    a = table['a', 'b', 'c']
+    b = table['d', 'e']
+    c = table['f', 'h']
+
+    joined = ibis.cross_join(a, b, c)
+    expected = a.cross_join(b.cross_join(c))
+    assert joined.equals(expected)
+
+
+def test_join_compound_boolean_predicate(table):
+    # The user might have composed predicates through logical operations
+    pass
+
+
+def test_filter_join_unmaterialized(table):
+    table1 = ibis.table({'key1': 'string', 'key2': 'string',
+                        'value1': 'double'})
+    table2 = ibis.table({'key3': 'string', 'value2': 'double'})
+
+    # It works!
+    joined = table1.inner_join(table2, [table1['key1'] == table2['key3']])
+    filtered = joined.filter([table1.value1 > 0])
+    repr(filtered)
+
+
+def test_join_overlapping_column_names(table):
+    t1 = ibis.table([('foo', 'string'),
+                     ('bar', 'string'),
+                     ('value1', 'double')])
+    t2 = ibis.table([('foo', 'string'),
+                     ('bar', 'string'),
+                     ('value2', 'double')])
+
+    joined = t1.join(t2, 'foo')
+    expected = t1.join(t2, t1.foo == t2.foo)
+    assert_equal(joined, expected)
+
+    joined = t1.join(t2, ['foo', 'bar'])
+    expected = t1.join(t2, [t1.foo == t2.foo,
+                            t1.bar == t2.bar])
+    assert_equal(joined, expected)
+
+
+def test_join_key_alternatives(con):
+    t1 = con.table('star1')
+    t2 = con.table('star2')
+
+    # Join with tuples
+    joined = t1.inner_join(t2, [('foo_id', 'foo_id')])
+    joined2 = t1.inner_join(t2, [(t1.foo_id, t2.foo_id)])
+
+    # Join with single expr
+    joined3 = t1.inner_join(t2, t1.foo_id == t2.foo_id)
+
+    expected = t1.inner_join(t2, [t1.foo_id == t2.foo_id])
+
+    assert_equal(joined, expected)
+    assert_equal(joined2, expected)
+    assert_equal(joined3, expected)
+
+    with pytest.raises(com.ExpressionError):
+        t1.inner_join(t2, [('foo_id', 'foo_id', 'foo_id')])
+
+
+def test_join_invalid_refs(con):
+    t1 = con.table('star1')
+    t2 = con.table('star2')
+    t3 = con.table('star3')
+
+    predicate = t1.bar_id == t3.bar_id
+    with pytest.raises(com.RelationError):
+        t1.inner_join(t2, [predicate])
+
+
+def test_join_non_boolean_expr(con):
+    t1 = con.table('star1')
+    t2 = con.table('star2')
+
+    # oops
+    predicate = t1.f * t2.value1
+    with pytest.raises(com.ExpressionError):
+        t1.inner_join(t2, [predicate])
+
+
+def test_unravel_compound_equijoin(table):
+    t1 = ibis.table([
+        ('key1', 'string'),
+        ('key2', 'string'),
+        ('key3', 'string'),
+        ('value1', 'double')
+    ], 'foo_table')
+
+    t2 = ibis.table([
+        ('key1', 'string'),
+        ('key2', 'string'),
+        ('key3', 'string'),
+        ('value2', 'double')
+    ], 'bar_table')
+
+    p1 = t1.key1 == t2.key1
+    p2 = t1.key2 == t2.key2
+    p3 = t1.key3 == t2.key3
+
+    joined = t1.inner_join(t2, [p1 & p2 & p3])
+    expected = t1.inner_join(t2, [p1, p2, p3])
+    assert_equal(joined, expected)
+
+
+def test_join_add_prefixes(table):
+    pass
+
+
+def test_join_nontrivial_exprs(table):
+    pass
+
+
+def test_union(table):
+    schema1 = [
+        ('key', 'string'),
+        ('value', 'double')
+    ]
+    schema2 = [
+        ('key', 'string'),
+        ('key2', 'string'),
+        ('value', 'double')
+    ]
+    t1 = ibis.table(schema1, 'foo')
+    t2 = ibis.table(schema1, 'bar')
+    t3 = ibis.table(schema2, 'baz')
+
+    result = t1.union(t2)
+    assert isinstance(result.op(), ops.Union)
+    assert not result.op().distinct
+
+    result = t1.union(t2, distinct=True)
+    assert isinstance(result.op(), ops.Union)
+    assert result.op().distinct
+
+    with pytest.raises(ir.RelationError):
+        t1.union(t3)
+
+
+def test_column_ref_on_projection_rename(con):
+    region = con.table('tpch_region')
+    nation = con.table('tpch_nation')
+    customer = con.table('tpch_customer')
+
+    joined = (region.inner_join(
+        nation, [region.r_regionkey == nation.n_regionkey])
+        .inner_join(
+            customer, [customer.c_nationkey == nation.n_nationkey]))
+
+    proj_exprs = [customer, nation.n_name.name('nation'),
+                  region.r_name.name('region')]
+    joined = joined.projection(proj_exprs)
+
+    metrics = [joined.c_acctbal.sum().name('metric')]
+
+    # it works!
+    joined.aggregate(metrics, by=['region'])
+
+
+@pytest.fixture
+def t1():
+    return ibis.table([
+        ('key1', 'string'),
+        ('key2', 'string'),
+        ('value1', 'double')
+    ], 'foo')
+
+
+@pytest.fixture
+def t2():
+    return ibis.table([
+        ('key1', 'string'),
+        ('key2', 'string')
+    ], 'bar')
+
+
+def test_simple_existence_predicate(t1, t2):
+    cond = (t1.key1 == t2.key1).any()
+
+    assert isinstance(cond, ir.BooleanArray)
+    op = cond.op()
+    assert isinstance(op, ops.Any)
+
+    # it works!
+    expr = t1[cond]
+    assert isinstance(expr.op(), ops.Selection)
+
+
+def test_cannot_use_existence_expression_in_join(table):
+    # Join predicates must consist only of comparisons
+    pass
+
+
+def test_not_exists_predicate(t1, t2):
+    cond = -(t1.key1 == t2.key1).any()
+    assert isinstance(cond.op(), ops.NotAny)
+
+
+def test_aggregate_metrics(table):
+
+    functions = [lambda x: x.e.sum().name('esum'),
+                 lambda x: x.f.sum().name('fsum')]
+    exprs = [table.e.sum().name('esum'),
+             table.f.sum().name('fsum')]
+
+    result = table.aggregate(functions[0])
+    expected = table.aggregate(exprs[0])
+    assert_equal(result, expected)
+
+    result = table.aggregate(functions)
+    expected = table.aggregate(exprs)
+    assert_equal(result, expected)
+
+
+def test_group_by_keys(table):
+    m = table.mutate(foo=table.f * 2,
+                          bar=table.e / 2)
+
+    expr = m.group_by(lambda x: x.foo).size()
+    expected = m.group_by('foo').size()
+    assert_equal(expr, expected)
+
+    expr = m.group_by([lambda x: x.foo, lambda x: x.bar]).size()
+    expected = m.group_by(['foo', 'bar']).size()
+    assert_equal(expr, expected)
+
+
+def test_having(table):
+    m = table.mutate(foo=table.f * 2,
+                          bar=table.e / 2)
+
+    expr = (m.group_by('foo')
+            .having(lambda x: x.foo.sum() > 10)
+            .size())
+    expected = (m.group_by('foo')
+                .having(m.foo.sum() > 10)
                 .size())
-        expected = (m.group_by('foo')
-                    .having(m.foo.sum() > 10)
-                    .size())
 
-        assert_equal(expr, expected)
+    assert_equal(expr, expected)
 
-    def test_filter(self):
-        m = self.table.mutate(foo=self.table.f * 2,
-                              bar=self.table.e / 2)
 
-        result = m.filter(lambda x: x.foo > 10)
-        result2 = m[lambda x: x.foo > 10]
-        expected = m[m.foo > 10]
+def test_filter(table):
+    m = table.mutate(foo=table.f * 2,
+                          bar=table.e / 2)
 
-        assert_equal(result, expected)
-        assert_equal(result2, expected)
+    result = m.filter(lambda x: x.foo > 10)
+    result2 = m[lambda x: x.foo > 10]
+    expected = m[m.foo > 10]
 
-        result = m.filter([lambda x: x.foo > 10,
-                           lambda x: x.bar < 0])
-        expected = m.filter([m.foo > 10, m.bar < 0])
-        assert_equal(result, expected)
+    assert_equal(result, expected)
+    assert_equal(result2, expected)
 
-    def test_sort_by(self):
-        m = self.table.mutate(foo=self.table.e + self.table.f)
+    result = m.filter([lambda x: x.foo > 10,
+                       lambda x: x.bar < 0])
+    expected = m.filter([m.foo > 10, m.bar < 0])
+    assert_equal(result, expected)
 
-        result = m.sort_by(lambda x: -x.foo)
-        expected = m.sort_by(-m.foo)
-        assert_equal(result, expected)
 
-        result = m.sort_by(lambda x: ibis.desc(x.foo))
-        expected = m.sort_by(ibis.desc('foo'))
-        assert_equal(result, expected)
+def test_sort_by(table):
+    m = table.mutate(foo=table.e + table.f)
 
-        result = m.sort_by(ibis.desc(lambda x: x.foo))
-        expected = m.sort_by(ibis.desc('foo'))
-        assert_equal(result, expected)
+    result = m.sort_by(lambda x: -x.foo)
+    expected = m.sort_by(-m.foo)
+    assert_equal(result, expected)
 
-    def test_projection(self):
-        m = self.table.mutate(foo=self.table.f * 2)
+    result = m.sort_by(lambda x: ibis.desc(x.foo))
+    expected = m.sort_by(ibis.desc('foo'))
+    assert_equal(result, expected)
 
-        def f(x):
-            return (x.foo * 2).name('bar')
+    result = m.sort_by(ibis.desc(lambda x: x.foo))
+    expected = m.sort_by(ibis.desc('foo'))
+    assert_equal(result, expected)
 
-        result = m.projection([f, 'f'])
-        result2 = m[f, 'f']
-        expected = m.projection([f(m), 'f'])
-        assert_equal(result, expected)
-        assert_equal(result2, expected)
 
-    def test_mutate(self):
-        m = self.table.mutate(foo=self.table.f * 2)
+def test_projection(table):
+    m = table.mutate(foo=table.f * 2)
 
-        def g(x):
-            return x.foo * 2
+    def f(x):
+        return (x.foo * 2).name('bar')
 
-        def h(x):
-            return x.bar * 2
+    result = m.projection([f, 'f'])
+    result2 = m[f, 'f']
+    expected = m.projection([f(m), 'f'])
+    assert_equal(result, expected)
+    assert_equal(result2, expected)
 
-        result = m.mutate(bar=g).mutate(baz=h)
 
-        m2 = m.mutate(bar=g(m))
-        expected = m2.mutate(baz=h(m2))
+def test_mutate(table):
+    m = table.mutate(foo=table.f * 2)
 
-        assert_equal(result, expected)
+    def g(x):
+        return x.foo * 2
 
-    def test_add_column(self):
-        def g(x):
-            return x.f * 2
+    def h(x):
+        return x.bar * 2
 
-        result = self.table.add_column(g, name='foo')
-        expected = self.table.mutate(foo=g)
-        assert_equal(result, expected)
+    result = m.mutate(bar=g).mutate(baz=h)
 
-    def test_groupby_mutate(self):
-        t = self.table
+    m2 = m.mutate(bar=g(m))
+    expected = m2.mutate(baz=h(m2))
 
-        g = t.group_by('g').order_by('f')
-        expr = g.mutate(foo=lambda x: x.f.lag(),
-                        bar=lambda x: x.f.rank())
-        expected = g.mutate(foo=t.f.lag(),
-                            bar=t.f.rank())
+    assert_equal(result, expected)
 
-        assert_equal(expr, expected)
 
-    def test_groupby_projection(self):
-        t = self.table
+def test_add_column(table):
+    def g(x):
+        return x.f * 2
 
-        g = t.group_by('g').order_by('f')
-        expr = g.projection([lambda x: x.f.lag().name('foo'),
-                             lambda x: x.f.rank().name('bar')])
-        expected = g.projection([t.f.lag().name('foo'),
-                                 t.f.rank().name('bar')])
+    result = table.add_column(g, name='foo')
+    expected = table.mutate(foo=g)
+    assert_equal(result, expected)
 
-        assert_equal(expr, expected)
 
-    def test_set_column(self):
-        def g(x):
-            return x.f * 2
+def test_groupby_mutate(table):
+    t = table
 
-        result = self.table.set_column('f', g)
-        expected = self.table.set_column('f', self.table.f * 2)
-        assert_equal(result, expected)
+    g = t.group_by('g').order_by('f')
+    expr = g.mutate(foo=lambda x: x.f.lag(),
+                    bar=lambda x: x.f.rank())
+    expected = g.mutate(foo=t.f.lag(),
+                        bar=t.f.rank())
+
+    assert_equal(expr, expected)
+
+
+def test_groupby_projection(table):
+    t = table
+
+    g = t.group_by('g').order_by('f')
+    expr = g.projection([lambda x: x.f.lag().name('foo'),
+                         lambda x: x.f.rank().name('bar')])
+    expected = g.projection([t.f.lag().name('foo'),
+                             t.f.rank().name('bar')])
+
+    assert_equal(expr, expected)
+
+
+def test_set_column(table):
+    def g(x):
+        return x.f * 2
+
+    result = table.set_column('f', g)
+    expected = table.set_column('f', table.f * 2)
+    assert_equal(result, expected)

--- a/ibis/expr/tests/test_window_functions.py
+++ b/ibis/expr/tests/test_window_functions.py
@@ -12,146 +12,152 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ibis
+import pytest
 
-from ibis.compat import unittest
-from ibis.expr.tests.mocks import BasicTestCase
+import ibis
 
 from ibis.tests.util import assert_equal
 
 
-class TestWindowFunctions(BasicTestCase, unittest.TestCase):
+@pytest.fixture
+def t(con):
+    return con.table('alltypes')
 
-    def setUp(self):
-        BasicTestCase.setUp(self)
-        self.t = self.con.table('alltypes')
 
-    def test_compose_group_by_apis(self):
-        t = self.t
-        w = ibis.window(group_by=t.g, order_by=t.f)
+def test_compose_group_by_apis(t):
+    t = t
+    w = ibis.window(group_by=t.g, order_by=t.f)
 
-        diff = t.d - t.d.lag()
-        grouped = t.group_by('g').order_by('f')
+    diff = t.d - t.d.lag()
+    grouped = t.group_by('g').order_by('f')
 
-        expr = grouped[t, diff.name('diff')]
-        expr2 = grouped.mutate(diff=diff)
-        expr3 = grouped.mutate([diff.name('diff')])
+    expr = grouped[t, diff.name('diff')]
+    expr2 = grouped.mutate(diff=diff)
+    expr3 = grouped.mutate([diff.name('diff')])
 
-        window_expr = (t.d - t.d.lag().over(w)).name('diff')
-        expected = t.projection([t, window_expr])
+    window_expr = (t.d - t.d.lag().over(w)).name('diff')
+    expected = t.projection([t, window_expr])
 
-        assert_equal(expr, expected)
-        assert_equal(expr, expr2)
-        assert_equal(expr, expr3)
+    assert_equal(expr, expected)
+    assert_equal(expr, expr2)
+    assert_equal(expr, expr3)
 
-    def test_combine_windows(self):
-        t = self.t
-        w1 = ibis.window(group_by=t.g, order_by=t.f)
-        w2 = ibis.window(preceding=5, following=5)
 
-        w3 = w1.combine(w2)
-        expected = ibis.window(group_by=t.g, order_by=t.f,
-                               preceding=5, following=5)
-        assert_equal(w3, expected)
+def test_combine_windows(t):
+    t = t
+    w1 = ibis.window(group_by=t.g, order_by=t.f)
+    w2 = ibis.window(preceding=5, following=5)
 
-        w4 = ibis.window(group_by=t.a, order_by=t.e)
-        w5 = w3.combine(w4)
-        expected = ibis.window(group_by=[t.g, t.a],
-                               order_by=[t.f, t.e],
-                               preceding=5, following=5)
-        assert_equal(w5, expected)
+    w3 = w1.combine(w2)
+    expected = ibis.window(group_by=t.g, order_by=t.f,
+                           preceding=5, following=5)
+    assert_equal(w3, expected)
 
-    def test_over_auto_bind(self):
-        # GH #542
-        t = self.t
+    w4 = ibis.window(group_by=t.a, order_by=t.e)
+    w5 = w3.combine(w4)
+    expected = ibis.window(group_by=[t.g, t.a],
+                           order_by=[t.f, t.e],
+                           preceding=5, following=5)
+    assert_equal(w5, expected)
 
-        w = ibis.window(group_by='g', order_by='f')
 
-        expr = t.f.lag().over(w)
+def test_over_auto_bind(t):
+    # GH #542
+    t = t
 
-        actual_window = expr.op().args[1]
-        expected = ibis.window(group_by=t.g, order_by=t.f)
-        assert_equal(actual_window, expected)
+    w = ibis.window(group_by='g', order_by='f')
 
-    def test_window_function_bind(self):
-        # GH #532
-        t = self.t
+    expr = t.f.lag().over(w)
 
-        w = ibis.window(group_by=lambda x: x.g,
-                        order_by=lambda x: x.f)
+    actual_window = expr.op().args[1]
+    expected = ibis.window(group_by=t.g, order_by=t.f)
+    assert_equal(actual_window, expected)
 
-        expr = t.f.lag().over(w)
 
-        actual_window = expr.op().args[1]
-        expected = ibis.window(group_by=t.g, order_by=t.f)
-        assert_equal(actual_window, expected)
+def test_window_function_bind(t):
+    # GH #532
+    t = t
 
-    def test_auto_windowize_analysis_bug(self):
-        # GH #544
-        t = self.con.table('airlines')
+    w = ibis.window(group_by=lambda x: x.g,
+                    order_by=lambda x: x.f)
 
-        def metric(x):
-            return x.arrdelay.mean().name('avg_delay')
+    expr = t.f.lag().over(w)
 
-        annual_delay = (t[t.dest.isin(['JFK', 'SFO'])]
-                        .group_by(['dest', 'year'])
-                        .aggregate(metric))
-        what = annual_delay.group_by('dest')
-        enriched = what.mutate(grand_avg=annual_delay.avg_delay.mean())
+    actual_window = expr.op().args[1]
+    expected = ibis.window(group_by=t.g, order_by=t.f)
+    assert_equal(actual_window, expected)
 
-        expr = (annual_delay.avg_delay.mean().name('grand_avg')
-                .over(ibis.window(group_by=annual_delay.dest)))
-        expected = annual_delay[annual_delay, expr]
 
-        assert_equal(enriched, expected)
+def test_auto_windowize_analysis_bug(con):
+    # GH #544
+    t = con.table('airlines')
 
-    def test_mutate_sorts_keys(self):
-        t = self.con.table('airlines')
-        m = t.arrdelay.mean()
-        g = t.group_by('dest')
+    def metric(x):
+        return x.arrdelay.mean().name('avg_delay')
 
-        result = g.mutate(zzz=m, yyy=m, ddd=m, ccc=m, bbb=m, aaa=m)
+    annual_delay = (t[t.dest.isin(['JFK', 'SFO'])]
+                    .group_by(['dest', 'year'])
+                    .aggregate(metric))
+    what = annual_delay.group_by('dest')
+    enriched = what.mutate(grand_avg=annual_delay.avg_delay.mean())
 
-        expected = g.mutate([m.name('aaa'), m.name('bbb'), m.name('ccc'),
-                             m.name('ddd'), m.name('yyy'), m.name('zzz')])
+    expr = (annual_delay.avg_delay.mean().name('grand_avg')
+            .over(ibis.window(group_by=annual_delay.dest)))
+    expected = annual_delay[annual_delay, expr]
 
-        assert_equal(result, expected)
+    assert_equal(enriched, expected)
 
-    def test_window_bind_to_table(self):
-        w = ibis.window(group_by='g', order_by=ibis.desc('f'))
 
-        w2 = w.bind(self.t)
-        expected = ibis.window(group_by=self.t.g,
-                               order_by=ibis.desc(self.t.f))
+def test_mutate_sorts_keys(con):
+    t = con.table('airlines')
+    m = t.arrdelay.mean()
+    g = t.group_by('dest')
 
-        assert_equal(w2, expected)
+    result = g.mutate(zzz=m, yyy=m, ddd=m, ccc=m, bbb=m, aaa=m)
 
-    def test_preceding_following_validate(self):
-        # these all work
-        [
-            ibis.window(preceding=0),
-            ibis.window(following=0),
-            ibis.window(preceding=0, following=0),
-            ibis.window(preceding=(None, 4)),
-            ibis.window(preceding=(10, 4)),
-            ibis.window(following=(4, None)),
-            ibis.window(following=(4, 10))
-        ]
+    expected = g.mutate([m.name('aaa'), m.name('bbb'), m.name('ccc'),
+                         m.name('ddd'), m.name('yyy'), m.name('zzz')])
 
-        # these are ill-specified
-        error_cases = [
-            lambda: ibis.window(preceding=(1, 3)),
-            lambda: ibis.window(preceding=(3, 1), following=2),
-            lambda: ibis.window(preceding=(3, 1), following=(2, 4)),
-            lambda: ibis.window(preceding=-1),
-            lambda: ibis.window(following=-1),
-            lambda: ibis.window(preceding=(-1, 2)),
-            lambda: ibis.window(following=(2, -1))
-        ]
+    assert_equal(result, expected)
 
-        for i, case in enumerate(error_cases):
-            with self.assertRaises(Exception):
-                case()
 
-    def test_window_equals(self):
-        pass
+def test_window_bind_to_table(t):
+    w = ibis.window(group_by='g', order_by=ibis.desc('f'))
+
+    w2 = w.bind(t)
+    expected = ibis.window(group_by=t.g,
+                           order_by=ibis.desc(t.f))
+
+    assert_equal(w2, expected)
+
+
+def test_preceding_following_validate(t):
+    # these all work
+    [
+        ibis.window(preceding=0),
+        ibis.window(following=0),
+        ibis.window(preceding=0, following=0),
+        ibis.window(preceding=(None, 4)),
+        ibis.window(preceding=(10, 4)),
+        ibis.window(following=(4, None)),
+        ibis.window(following=(4, 10))
+    ]
+
+    # these are ill-specified
+    error_cases = [
+        lambda: ibis.window(preceding=(1, 3)),
+        lambda: ibis.window(preceding=(3, 1), following=2),
+        lambda: ibis.window(preceding=(3, 1), following=(2, 4)),
+        lambda: ibis.window(preceding=-1),
+        lambda: ibis.window(following=-1),
+        lambda: ibis.window(preceding=(-1, 2)),
+        lambda: ibis.window(following=(2, -1))
+    ]
+
+    for i, case in enumerate(error_cases):
+        with pytest.raises(Exception):
+            case()
+
+
+def test_window_equals(t):
+    pass

--- a/ibis/impala/tests/conftest.py
+++ b/ibis/impala/tests/conftest.py
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 from ibis.tests.conftest import *  # noqa
+from ibis.expr.tests.conftest import con

--- a/ibis/impala/tests/test_window.py
+++ b/ibis/impala/tests/test_window.py
@@ -13,231 +13,238 @@
 # limitations under the License.
 
 
+import pytest
+
 from ibis import window
 import ibis
 
 from ibis.impala.compiler import to_sql
-from ibis.expr.tests.mocks import BasicTestCase
 from ibis.compat import unittest
 from ibis.tests.util import assert_equal
 import ibis.common as com
 
 
-class TestWindowFunctions(BasicTestCase, unittest.TestCase):
+def assert_sql_equal(expr, expected):
+    result = to_sql(expr)
+    assert result == expected
 
-    def _check_sql(self, expr, expected):
-        result = to_sql(expr)
-        assert result == expected
 
-    def test_aggregate_in_projection(self):
-        t = self.con.table('alltypes')
-        proj = t[t, (t.f / t.f.sum()).name('normed_f')]
+def test_aggregate_in_projection(con):
+    t = con.table('alltypes')
+    proj = t[t, (t.f / t.f.sum()).name('normed_f')]
 
-        expected = """\
+    expected = """\
 SELECT *, `f` / sum(`f`) OVER () AS `normed_f`
 FROM alltypes"""
-        self._check_sql(proj, expected)
+    assert_sql_equal(proj, expected)
 
-    def test_add_default_order_by(self):
-        t = self.con.table('alltypes')
 
-        first = t.f.first().name('first')
-        last = t.f.last().name('last')
-        lag = t.f.lag().name('lag')
-        diff = (t.f.lead() - t.f).name('fwd_diff')
-        lag2 = t.f.lag().over(window(order_by=t.d)).name('lag2')
-        grouped = t.group_by('g')
-        proj = grouped.mutate([lag, diff, first, last, lag2])
-        expected = """\
+def test_add_default_order_by(con):
+    t = con.table('alltypes')
+
+    first = t.f.first().name('first')
+    last = t.f.last().name('last')
+    lag = t.f.lag().name('lag')
+    diff = (t.f.lead() - t.f).name('fwd_diff')
+    lag2 = t.f.lag().over(window(order_by=t.d)).name('lag2')
+    grouped = t.group_by('g')
+    proj = grouped.mutate([lag, diff, first, last, lag2])
+    expected = """\
 SELECT *, lag(`f`) OVER (PARTITION BY `g` ORDER BY `f`) AS `lag`,
        lead(`f`) OVER (PARTITION BY `g` ORDER BY `f`) - `f` AS `fwd_diff`,
        first_value(`f`) OVER (PARTITION BY `g` ORDER BY `f`) AS `first`,
        last_value(`f`) OVER (PARTITION BY `g` ORDER BY `f`) AS `last`,
        lag(`f`) OVER (PARTITION BY `g` ORDER BY `d`) AS `lag2`
 FROM alltypes"""
-        self._check_sql(proj, expected)
+    assert_sql_equal(proj, expected)
 
-    def test_window_frame_specs(self):
-        t = self.con.table('alltypes')
 
-        ex_template = """\
+@pytest.mark.parametrize(
+    ['window', 'frame'],
+    [
+        (window(preceding=0),
+         'range between current row and unbounded following'),
+
+        (window(following=0),
+         'range between unbounded preceding and current row'),
+
+        (window(preceding=5),
+         'rows between 5 preceding and unbounded following'),
+        (window(preceding=5, following=0),
+         'rows between 5 preceding and current row'),
+        (window(preceding=5, following=2),
+         'rows between 5 preceding and 2 following'),
+        (window(following=2),
+         'rows between unbounded preceding and 2 following'),
+        (window(following=2, preceding=0),
+         'rows between current row and 2 following'),
+        (window(preceding=5),
+         'rows between 5 preceding and unbounded following'),
+        (window(following=[5, 10]),
+         'rows between 5 following and 10 following'),
+        (window(preceding=[10, 5]),
+         'rows between 10 preceding and 5 preceding'),
+
+        # # cumulative windows
+        (ibis.cumulative_window(),
+         'range between unbounded preceding and current row'),
+
+        # # trailing windows
+        (ibis.trailing_window(10),
+         'rows between 10 preceding and current row'),
+    ]
+)
+def test_window_frame_specs(con, window, frame):
+    t = con.table('alltypes')
+
+    ex_template = """\
 SELECT sum(`d`) OVER (ORDER BY `f` {0}) AS `foo`
 FROM alltypes"""
 
-        cases = [
-            (window(preceding=0),
-             'range between current row and unbounded following'),
+    w2 = window.order_by(t.f)
+    expr = t.projection([t.d.sum().over(w2).name('foo')])
+    expected = ex_template.format(frame.upper())
+    assert_sql_equal(expr, expected)
 
-            (window(following=0),
-             'range between unbounded preceding and current row'),
 
-            (window(preceding=5),
-             'rows between 5 preceding and unbounded following'),
-            (window(preceding=5, following=0),
-             'rows between 5 preceding and current row'),
-            (window(preceding=5, following=2),
-             'rows between 5 preceding and 2 following'),
-            (window(following=2),
-             'rows between unbounded preceding and 2 following'),
-            (window(following=2, preceding=0),
-             'rows between current row and 2 following'),
-            (window(preceding=5),
-             'rows between 5 preceding and unbounded following'),
-            (window(following=[5, 10]),
-             'rows between 5 following and 10 following'),
-            (window(preceding=[10, 5]),
-             'rows between 10 preceding and 5 preceding'),
+def test_cumulative_functions(con):
+    t = con.table('alltypes')
 
-            # # cumulative windows
-            (ibis.cumulative_window(),
-             'range between unbounded preceding and current row'),
+    w = ibis.window(order_by=t.d)
+    exprs = [
+        (t.f.cumsum().over(w), t.f.sum().over(w)),
+        (t.f.cummin().over(w), t.f.min().over(w)),
+        (t.f.cummax().over(w), t.f.max().over(w)),
+        (t.f.cummean().over(w), t.f.mean().over(w)),
+    ]
 
-            # # trailing windows
-            (ibis.trailing_window(10),
-             'rows between 10 preceding and current row'),
-        ]
+    for cumulative, static in exprs:
+        actual = cumulative.name('foo')
+        expected = static.over(ibis.cumulative_window()).name('foo')
 
-        for w, frame in cases:
-            w2 = w.order_by(t.f)
-            expr = t.projection([t.d.sum().over(w2).name('foo')])
-            expected = ex_template.format(frame.upper())
-            self._check_sql(expr, expected)
+        expr1 = t.projection(actual)
+        expr2 = t.projection(expected)
 
-    def test_cumulative_functions(self):
-        t = self.con.table('alltypes')
+        assert to_sql(expr1) == to_sql(expr2)
 
-        w = ibis.window(order_by=t.d)
-        exprs = [
-            (t.f.cumsum().over(w), t.f.sum().over(w)),
-            (t.f.cummin().over(w), t.f.min().over(w)),
-            (t.f.cummax().over(w), t.f.max().over(w)),
-            (t.f.cummean().over(w), t.f.mean().over(w)),
-        ]
 
-        for cumulative, static in exprs:
-            actual = cumulative.name('foo')
-            expected = static.over(ibis.cumulative_window()).name('foo')
+def test_nested_analytic_function(con):
+    t = con.table('alltypes')
 
-            expr1 = t.projection(actual)
-            expr2 = t.projection(expected)
-
-            self._compare_sql(expr1, expr2)
-
-    def _compare_sql(self, e1, e2):
-        s1 = to_sql(e1)
-        s2 = to_sql(e2)
-        assert s1 == s2
-
-    def test_nested_analytic_function(self):
-        t = self.con.table('alltypes')
-
-        w = window(order_by=t.f)
-        expr = (t.f - t.f.lag()).lag().over(w).name('foo')
-        result = t.projection([expr])
-        expected = """\
+    w = window(order_by=t.f)
+    expr = (t.f - t.f.lag()).lag().over(w).name('foo')
+    result = t.projection([expr])
+    expected = """\
 SELECT lag(`f` - lag(`f`) OVER (ORDER BY `f`)) \
 OVER (ORDER BY `f`) AS `foo`
 FROM alltypes"""
-        self._check_sql(result, expected)
+    assert_sql_equal(result, expected)
 
-    def test_rank_functions(self):
-        t = self.con.table('alltypes')
+def test_rank_functions(con):
+    t = con.table('alltypes')
 
-        proj = t[t.g, t.f.rank().name('minr'),
-                 t.f.dense_rank().name('denser')]
-        expected = """\
+    proj = t[t.g, t.f.rank().name('minr'),
+             t.f.dense_rank().name('denser')]
+    expected = """\
 SELECT `g`, rank() OVER (ORDER BY `f`) - 1 AS `minr`,
        dense_rank() OVER (ORDER BY `f`) - 1 AS `denser`
 FROM alltypes"""
-        self._check_sql(proj, expected)
+    assert_sql_equal(proj, expected)
 
-    def test_multiple_windows(self):
-        t = self.con.table('alltypes')
+def test_multiple_windows(con):
+    t = con.table('alltypes')
 
-        w = window(group_by=t.g)
+    w = window(group_by=t.g)
 
-        expr = t.f.sum().over(w) - t.f.sum()
-        proj = t.projection([t.g, expr.name('result')])
+    expr = t.f.sum().over(w) - t.f.sum()
+    proj = t.projection([t.g, expr.name('result')])
 
-        expected = """\
+    expected = """\
 SELECT `g`, sum(`f`) OVER (PARTITION BY `g`) - sum(`f`) OVER () AS `result`
 FROM alltypes"""
-        self._check_sql(proj, expected)
+    assert_sql_equal(proj, expected)
 
-    def test_order_by_desc(self):
-        t = self.con.table('alltypes')
+def test_order_by_desc(con):
+    t = con.table('alltypes')
 
-        w = window(order_by=ibis.desc(t.f))
+    w = window(order_by=ibis.desc(t.f))
 
-        proj = t[t.f, ibis.row_number().over(w).name('revrank')]
-        expected = """\
+    proj = t[t.f, ibis.row_number().over(w).name('revrank')]
+    expected = """\
 SELECT `f`, row_number() OVER (ORDER BY `f` DESC) - 1 AS `revrank`
 FROM alltypes"""
-        self._check_sql(proj, expected)
+    assert_sql_equal(proj, expected)
 
-        expr = (t.group_by('g')
-                .order_by(ibis.desc(t.f))
-                [t.d.lag().name('foo'), t.a.max()])
-        expected = """\
+    expr = (t.group_by('g')
+            .order_by(ibis.desc(t.f))
+            [t.d.lag().name('foo'), t.a.max()])
+    expected = """\
 SELECT lag(`d`) OVER (PARTITION BY `g` ORDER BY `f` DESC) AS `foo`,
        max(`a`) OVER (PARTITION BY `g` ORDER BY `f` DESC) AS `max`
 FROM alltypes"""
-        self._check_sql(expr, expected)
+    assert_sql_equal(expr, expected)
 
-    def test_row_number_requires_order_by(self):
-        t = self.con.table('alltypes')
+def test_row_number_requires_order_by(con):
+    t = con.table('alltypes')
 
-        with self.assertRaises(com.ExpressionError):
-            (t.group_by(t.g)
-             .mutate(ibis.row_number().name('foo')))
+    with pytest.raises(com.ExpressionError):
+        (t.group_by(t.g)
+         .mutate(ibis.row_number().name('foo')))
 
-        expr = (t.group_by(t.g)
-                .order_by(t.f)
-                .mutate(ibis.row_number().name('foo')))
+    expr = (t.group_by(t.g)
+            .order_by(t.f)
+            .mutate(ibis.row_number().name('foo')))
 
-        expected = """\
+    expected = """\
 SELECT *, row_number() OVER (PARTITION BY `g` ORDER BY `f`) - 1 AS `foo`
 FROM alltypes"""
-        self._check_sql(expr, expected)
+    assert_sql_equal(expr, expected)
 
-    def test_unsupported_aggregate_functions(self):
-        t = self.con.table('alltypes')
-        w = ibis.window(order_by=t.d)
 
-        exprs = [
-            t.f.approx_nunique(),
-            t.f.approx_median(),
-            t.g.group_concat(),
-        ]
+@pytest.mark.parametrize(
+    ['column', 'op'],
+    [
+        ('f', 'approx_nunique'),
+        ('f', 'approx_median'),
+        ('g', 'group_concat'),
+    ]
+)
+def test_unsupported_aggregate_functions(con, column, op):
+    t = con.table('alltypes')
+    w = ibis.window(order_by=t.d)
+    expr = getattr(t[column], op)()
+    proj = t.projection([expr.over(w).name('foo')])
+    with pytest.raises(com.TranslationError):
+        to_sql(proj)
 
-        for expr in exprs:
-            with self.assertRaises(com.TranslationError):
-                proj = t.projection([expr.over(w).name('foo')])
-                to_sql(proj)
 
-    def test_propagate_nested_windows(self):
-        # GH #469
-        t = self.con.table('alltypes')
+def test_propagate_nested_windows(con):
+    # GH #469
+    t = con.table('alltypes')
 
-        w = ibis.window(group_by=t.g, order_by=t.f)
+    w = ibis.window(group_by=t.g, order_by=t.f)
 
-        col = (t.f - t.f.lag()).lag()
+    col = (t.f - t.f.lag()).lag()
 
-        # propagate down here!
-        result = col.over(w)
-        ex_expr = (t.f - t.f.lag().over(w)).lag().over(w)
-        assert_equal(result, ex_expr)
+    # propagate down here!
+    result = col.over(w)
+    ex_expr = (t.f - t.f.lag().over(w)).lag().over(w)
+    assert_equal(result, ex_expr)
 
-        expr = t.projection(col.over(w).name('foo'))
-        expected = """\
+    expr = t.projection(col.over(w).name('foo'))
+    expected = """\
 SELECT lag(`f` - lag(`f`) OVER (PARTITION BY `g` ORDER BY `f`)) \
 OVER (PARTITION BY `g` ORDER BY `f`) AS `foo`
 FROM alltypes"""
-        self._check_sql(expr, expected)
+    assert_sql_equal(expr, expected)
 
-    def test_math_on_windowed_expr(self):
-        # Window clause may not be found at top level of expression
-        pass
 
-    def test_group_by_then_different_sort_orders(self):
-        pass
+@pytest.mark.xfail
+def test_math_on_windowed_expr():
+    # Window clause may not be found at top level of expression
+    assert False
+
+
+@pytest.mark.xfail
+def test_group_by_then_different_sort_orders():
+    assert False


### PR DESCRIPTION
@wesm, this PR is an example of how pytest is typically used.  I'd like to get your feedback on whether this is something we could do going forward in ibis.

I've ported enough code to the pytest way of things to make the current expression, sqlite and postgres test suites pass (i.e., I haven't run against a real Impala instance)

Pros:
  - Less repetition with fixtures
  - Parameterized fixtures run each case of a series of repetitive tests as a single test, which makes the failing cases easier to track down
  - Easier to specify the difference between failure due to lack of implemenation (`xfail`) vs expected failures (`pytest.raises`)

Cons:
  - A bit of a perf penalty for the extra abstraction 3.34s for the master to 4.00s with this PR
  - A bit magical to have fixtures specified as function arguments if unfamiliar with pytest
  - Can be difficult to track down origin of failures during test discovery phase (this was my personal experience and there may be a better way since the last time I looked into this)