### PR TITLE
Draft of column lineage API

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,11 @@ machine:
   environment:
     IBIS_TEST_SQLITE_DB_PATH: $HOME/ibis-testing-data/ibis_testing.db
     IBIS_TEST_POSTGRES_DB: circle_test
+    IBIS_TEST_CRUNCHBASE_DB: $HOME/crunchbase.db
   post:
+    # download the crunchbase sqlite database, for lineage testing
+    - wget https://ibis-resources.s3.amazonaws.com/data/crunchbase/crunchbase.db
+
     # download the data
     - wget https://ibis-resources.s3.amazonaws.com/testing/ibis-testing-data.tar.gz
 

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -161,20 +161,14 @@ def lineage(expr, container=Stack):
     if not isinstance(expr, ir.ArrayExpr):
         raise TypeError('Input expression must be a column')
 
-    current_name = expr._name
-    c = container([(expr, current_name)])
+    c = container([(expr, expr._name)])
 
     seen = set()
     visitor = c.visitor
 
     # while we haven't visited everything
     while not c.empty:
-        node, proposed_name = c.get()
-
-        # if a new column name to traverse has appeared, look for that
-        # TODO: enforce that all columns are named?
-        if proposed_name is not None:
-            current_name = proposed_name
+        node, name = c.get()
 
         if node not in seen:
             seen.add(node)
@@ -182,6 +176,6 @@ def lineage(expr, container=Stack):
 
         # add our dependencies to the stack if they match our name or
         # are a valid expression to traverse
-        for arg in visitor(_get_args(node.op(), current_name)):
+        for arg in visitor(_get_args(node.op(), name)):
             if isinstance(arg, types):
-                c.put((arg, getattr(arg, '_name', None)))
+                c.put((arg, getattr(arg, '_name', name)))

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -110,19 +110,10 @@ def _get_args(op, name):
 
         # if Selection.selections is always columnar, could use an
         # OrderedDict to prevent scanning the whole thing
-        result = [col for col in result if col._name == name]
-        if isinstance(op.table, ops.Join):
-            result.append(op.table)
-        return result
+        return [col for col in result if col._name == name]
     elif isinstance(op, ops.Aggregation):
         assert name is not None, 'name is None'
-        return [
-            col for col in chain(op.by, op.agg_exprs)
-            if col._name == name
-        ]
-    elif isinstance(op, ops.Join):
-        assert name is not None, 'name is None'
-        return [op.left if name in op.left.columns else op.right]
+        return [col for col in chain(op.by, op.agg_exprs) if col._name == name]
     else:
         return op.args
 

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -1,0 +1,187 @@
+import queue as q
+from itertools import chain
+from toolz import identity
+
+import ibis.expr.types as ir
+import ibis.expr.operations as ops
+
+
+def roots(expr, types=(ops.PhysicalTable,)):
+    """Yield every node of a particular type on which an expression depends.
+
+    Parameters
+    ----------
+    expr : Expr
+        The expression to analyze
+    types : tuple(type), optional, default (:mod:`ibis.expr.operations.PhysicalTable`,)
+        The node types to traverse
+
+    Yields
+    ------
+    table : Expr
+        Unique node types on which an expression depends
+
+    Notes
+    -----
+    If your question is: "What nodes of type T does `expr` depend on?", then
+    you've come to the right place. By default, we yield the physical tables
+    that an expression depends on.
+    """
+    seen = set()
+
+    stack = list(reversed(expr.op().root_tables()))
+
+    while stack:
+        table = stack.pop()
+
+        if table not in seen:
+            seen.add(table)
+            yield table
+        else:
+            # flatten and reverse so that we traverse in preorder
+            stack.extend(reversed(list(chain.from_iterable(
+                arg.op().root_tables() for arg in table.flat_args()
+                if isinstance(arg, types)
+            ))))
+
+
+class Stack(object):
+
+    """Wrapper around a list to provide a common API for graph traversal
+    """
+
+    __slots__ = 'stack',
+
+    def __init__(self, stack=None):
+        self.stack = stack if stack is not None else []
+
+    def put(self, item):
+        self.stack.append(item)
+
+    def get(self):
+        return self.stack.pop()
+
+    @property
+    def empty(self):
+        return not self.stack
+
+    @property
+    def visitor(self):
+        return reversed
+
+
+class Queue(object):
+
+    """Wrapper around a queue.Queue to provide a common API for graph traversal
+    """
+
+    __slots__ = 'queue',
+
+    def __init__(self, queue=None):
+        self.queue = q.Queue()
+        if queue is not None:
+            for item in queue:
+                self.queue.put(item)
+
+    def put(self, item):
+        self.queue.put(item)
+
+    def get(self):
+        return self.queue.get()
+
+    @property
+    def empty(self):
+        return self.queue.empty()
+
+    @property
+    def visitor(self):
+        return identity
+
+
+def _get_args(op, name):
+    """Hack to get relevant arguments for lineage computation.
+
+    We need a better way to determine the relevant arguments of an expression.
+    """
+    # Could use multipledispatch here to avoid the pasta
+    if isinstance(op, ops.Selection):
+        result = op.selections
+
+        if name is None:
+            if isinstance(op.table, ops.Join):
+                result.append(op.table)
+            return result
+        else:
+            # if Selection.selections is always columnar, could use an
+            # OrderedDict to prevent scanning the whole thing
+            result = [col for col in result if col._name == name]
+            if isinstance(op.table, ops.Join):
+                result.append(op.table)
+            return result
+    elif isinstance(op, ops.Aggregation):
+        return [
+            col for col in chain(op.by, op.agg_exprs)
+            if col._name == name
+        ]
+    elif isinstance(op, ops.Join):
+        if name is None or (
+            name not in op.left.columns and name not in op.right.columns
+        ):
+            return [op.left, op.right]
+        else:
+            return [op.left if name in op.left.columns else op.right]
+    else:
+        return op.args
+
+
+def lineage(expr, container=Stack):
+    """Show the expression tree that comprises a column expression
+
+    Parameters
+    ----------
+    expr : Expr
+
+    Notes
+    -----
+    The order of graph traversal is configurable through the `container`
+    parameter.
+
+    Yields
+    ------
+    node : Expr
+    """
+    # TODO: seems a bit brittle, is everything fair game here?
+    types = (
+        ir.ArrayExpr,
+        ir.TableExpr,
+        ir.TableColumn,
+        ops.TableNode,  # includes Selection, Aggregation, Join
+    )
+
+    if not isinstance(expr, ir.ArrayExpr):
+        raise TypeError('Input expression must be a column')
+
+    current_name = expr._name
+    c = container([(expr, current_name)])
+
+    seen = set()
+    visitor = c.visitor
+
+    # while we haven't visited everything
+    while not c.empty:
+        node, proposed_name = c.get()
+
+        # if a new column name to traverse has appeared, look for that
+        # TODO: enforce that all columns are named?
+        if proposed_name is not None:
+            current_name = proposed_name
+
+        if node not in seen:
+            seen.add(node)
+            yield node
+
+        # add our dependencies to the stack if they match our name or
+        # are a valid expression to traverse
+        for arg in visitor(_get_args(node.op(), current_name)):
+            if isinstance(arg, types):
+                c.put((arg, getattr(arg, '_name', None)))

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -107,26 +107,19 @@ def _get_args(op, name):
     if isinstance(op, ops.Selection):
         result = op.selections
 
-        if name is None:
-            if isinstance(op.table, ops.Join):
-                result.append(op.table)
-            return result
-        else:
-            # if Selection.selections is always columnar, could use an
-            # OrderedDict to prevent scanning the whole thing
-            result = [col for col in result if col._name == name]
-            if isinstance(op.table, ops.Join):
-                result.append(op.table)
-            return result
+        # if Selection.selections is always columnar, could use an
+        # OrderedDict to prevent scanning the whole thing
+        result = [col for col in result if col._name == name]
+        if isinstance(op.table, ops.Join):
+            result.append(op.table)
+        return result
     elif isinstance(op, ops.Aggregation):
         return [
             col for col in chain(op.by, op.agg_exprs)
             if col._name == name
         ]
     elif isinstance(op, ops.Join):
-        if name is None or (
-            name not in op.left.columns and name not in op.right.columns
-        ):
+        if name not in op.left.columns and name not in op.right.columns:
             return [op.left, op.right]
         else:
             return [op.left if name in op.left.columns else op.right]

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -37,12 +37,12 @@ def roots(expr, types=(ops.PhysicalTable,)):
         if table not in seen:
             seen.add(table)
             yield table
-        else:
-            # flatten and reverse so that we traverse in preorder
-            stack.extend(reversed(list(chain.from_iterable(
-                arg.op().root_tables() for arg in table.flat_args()
-                if isinstance(arg, types)
-            ))))
+
+        # flatten and reverse so that we traverse in preorder
+        stack.extend(reversed(list(chain.from_iterable(
+            arg.op().root_tables() for arg in table.flat_args()
+            if isinstance(arg, types)
+        ))))
 
 
 class Stack(object):

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -118,7 +118,6 @@ def _get_args(op, name):
         return op.args
 
 
-
 def lineage(expr, container=Stack):
     """Show the expression tree that comprises a column expression
 

--- a/ibis/expr/tests/test_lineage.py
+++ b/ibis/expr/tests/test_lineage.py
@@ -1,13 +1,20 @@
+import os
 import pytest
 import ibis
 import ibis.expr.lineage as lin
 from ibis.tests.util import assert_equal
 
 
+IBIS_TEST_CRUNCHBASE_DB = os.environ.get(
+    'IBIS_TEST_CRUNCHBASE_DB',
+    'crunchbase.db'
+)
+
+
 @pytest.fixture
 def con():
     # make sure this is in the directory where you run py.test
-    return ibis.sqlite.connect('crunchbase.db')
+    return ibis.sqlite.connect(IBIS_TEST_CRUNCHBASE_DB)
 
 
 @pytest.fixture

--- a/ibis/expr/tests/test_lineage.py
+++ b/ibis/expr/tests/test_lineage.py
@@ -1,0 +1,156 @@
+import pytest
+import ibis
+import ibis.expr.lineage as lin
+from ibis.tests.util import assert_equal
+
+
+@pytest.fixture
+def con():
+    # make sure this is in the directory where you run py.test
+    return ibis.sqlite.connect('crunchbase.db')
+
+
+@pytest.fixture
+def companies(con):
+    return con.table('companies')
+
+
+@pytest.fixture
+def rounds(con):
+    return con.table('rounds')
+
+
+def test_lineage(companies):
+    # single table dependency
+    funding_buckets = [
+        0, 1000000, 10000000, 50000000, 100000000,  500000000, 1000000000
+    ]
+
+    bucket_names = [
+        '0 to 1m',
+        '1m to 10m',
+        '10m to 50m',
+        '50m to 100m',
+        '100m to 500m',
+        '500m to 1b',
+        'Over 1b',
+    ]
+
+    bucket = (
+        companies.funding_total_usd.bucket(funding_buckets, include_over=True)
+    )
+
+    mutated = companies.mutate(
+        bucket=bucket,
+        status=companies.status.fillna('Unknown')
+    )
+
+    filtered = mutated[
+        (companies.founded_at > '2010-01-01') | companies.founded_at.isnull()
+    ]
+
+    grouped = filtered.group_by(['bucket', 'status']).size()
+
+    joined = grouped.mutate(
+        bucket_name=lambda x: x.bucket.label(bucket_names).fillna('Unknown')
+    )
+
+    results = list(lin.lineage(bucket))
+    expected = [
+        bucket,
+        bucket.op().args[0],
+        bucket.op().args[0].op().args[1]
+    ]
+    for r, e in zip(results, expected):
+        assert_equal(r, e)
+
+    results = list(lin.lineage(mutated.bucket))
+    expected = [
+        mutated.bucket,
+        mutated,
+        mutated.op().selections[-1],
+        companies.funding_total_usd,
+        companies,
+    ]
+    for r, e in zip(results, expected):
+        assert_equal(r, e)
+
+    results = list(lin.lineage(filtered.bucket))
+    expected = [
+        filtered.bucket,
+        filtered,
+        mutated.op().selections[-1],
+        companies.funding_total_usd,
+        companies,
+    ]
+    for r, e in zip(results, expected):
+        assert_equal(r, e)
+
+    results = list(lin.lineage(grouped.bucket))
+    expected = [
+        grouped.bucket,
+        grouped,
+        grouped.op().by[0],
+        grouped.op().by[0].op().args[1],
+        grouped.op().by[0].op().args[1].op().selections[-1],
+        companies.funding_total_usd,
+        companies
+    ]
+    for r, e in zip(results, expected):
+        assert_equal(r, e)
+
+
+def test_lineage_multiple_parents(companies):
+    funding_per_year = companies.funding_total_usd / companies.funding_rounds
+    results = list(lin.lineage(funding_per_year))
+    expected = [
+        funding_per_year,
+        companies.funding_total_usd,
+        companies,
+        companies.funding_rounds,
+    ]
+    for r, e in zip(results, expected):
+        assert_equal(r, e)
+
+    # breadth first gives a slightly more aesthetically pleasing result
+    results = list(lin.lineage(funding_per_year, container=lin.Queue))
+    expected = [
+        funding_per_year,
+        companies.funding_total_usd,
+        companies.funding_rounds,
+        companies,
+    ]
+    for r, e in zip(results, expected):
+        assert_equal(r, e)
+
+
+def test_lineage_join(companies, rounds):
+    joined = companies.join(
+        rounds,
+        companies.first_funding_at.cast('timestamp').year() == rounds.funded_year
+    )
+    expr = joined[
+        companies.funding_total_usd,
+        rounds.funding_round_type,
+        rounds.company_city,
+        rounds.raised_amount_usd,
+    ]
+    perc_raised = (
+        expr.raised_amount_usd / expr.funding_total_usd
+    ).name('perc_raised')
+    results = list(lin.lineage(perc_raised))
+
+    expected = [
+        perc_raised,
+        expr.raised_amount_usd,
+        expr,
+        rounds.raised_amount_usd,
+        rounds,
+        expr.funding_total_usd,
+        # expr,  # *could* appear here as well, but we've already traversed it
+        companies.funding_total_usd,
+        companies
+    ]
+    assert len(results) == len(expected)
+    for i, (r, e) in enumerate(list(zip(results, expected))):
+        assert_equal(r, e)

--- a/ibis/expr/tests/test_lineage.py
+++ b/ibis/expr/tests/test_lineage.py
@@ -127,7 +127,9 @@ def test_lineage_multiple_parents(companies):
 def test_lineage_join(companies, rounds):
     joined = companies.join(
         rounds,
-        companies.first_funding_at.cast('timestamp').year() == rounds.funded_year
+        companies.first_funding_at.cast(
+            'timestamp'
+        ).year() == rounds.funded_year
     )
     expr = joined[
         companies.funding_total_usd,

--- a/ibis/expr/tests/test_lineage.py
+++ b/ibis/expr/tests/test_lineage.py
@@ -58,8 +58,8 @@ def test_lineage(companies):
     results = list(lin.lineage(bucket))
     expected = [
         bucket,
-        bucket.op().args[0],
-        bucket.op().args[0].op().args[1]
+        companies.funding_total_usd,
+        companies,
     ]
     for r, e in zip(results, expected):
         assert_equal(r, e)
@@ -68,7 +68,7 @@ def test_lineage(companies):
     expected = [
         mutated.bucket,
         mutated,
-        mutated.op().selections[-1],
+        bucket.name('bucket'),
         companies.funding_total_usd,
         companies,
     ]
@@ -79,7 +79,7 @@ def test_lineage(companies):
     expected = [
         filtered.bucket,
         filtered,
-        mutated.op().selections[-1],
+        bucket.name('bucket'),
         companies.funding_total_usd,
         companies,
     ]
@@ -90,9 +90,9 @@ def test_lineage(companies):
     expected = [
         grouped.bucket,
         grouped,
-        grouped.op().by[0],
-        grouped.op().by[0].op().args[1],
-        grouped.op().by[0].op().args[1].op().selections[-1],
+        filtered.bucket,
+        filtered,
+        bucket.name('bucket'),
         companies.funding_total_usd,
         companies
     ]

--- a/ibis/expr/tests/test_lineage.py
+++ b/ibis/expr/tests/test_lineage.py
@@ -154,3 +154,18 @@ def test_lineage_join(companies, rounds):
     assert len(results) == len(expected)
     for i, (r, e) in enumerate(list(zip(results, expected))):
         assert_equal(r, e)
+
+    results = list(lin.lineage(perc_raised, container=lin.Queue))
+    expected = [
+        perc_raised,
+        expr.raised_amount_usd,
+        expr.funding_total_usd,
+        expr,
+        rounds.raised_amount_usd,
+        companies.funding_total_usd,
+        rounds,
+        companies
+    ]
+    assert len(results) == len(expected)
+    for i, (r, e) in enumerate(list(zip(results, expected))):
+        assert_equal(r, e)

--- a/ibis/expr/tests/test_lineage.py
+++ b/ibis/expr/tests/test_lineage.py
@@ -152,7 +152,7 @@ def test_lineage_join(companies, rounds):
         companies
     ]
     assert len(results) == len(expected)
-    for i, (r, e) in enumerate(list(zip(results, expected))):
+    for r, e in zip(results, expected):
         assert_equal(r, e)
 
     results = list(lin.lineage(perc_raised, container=lin.Queue))
@@ -167,5 +167,5 @@ def test_lineage_join(companies, rounds):
         companies
     ]
     assert len(results) == len(expected)
-    for i, (r, e) in enumerate(list(zip(results, expected))):
+    for r, e in zip(results, expected):
         assert_equal(r, e)


### PR DESCRIPTION
This PR implements column lineage as a user-facing, top-level function in `ibis.expr.lineage` called `lineage`

Its input is an ibis column expression and its output is the expression plus all of its dependencies.

You can configure the order in which nodes show up by passing in either the `ibis.expr.lineage.Queue` or `ibis.expr.lineage.Stack` type objects.

Roughly, passing `Queue` will yield all physical table nodes last, while a `Stack` (the default) will yield physical tables as soon as they appear as a dependency