### PR TITLE
Fix incorrect SQL generated by row_number composed with other things

### DIFF
--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -1141,7 +1141,7 @@ def _value_list(translator, expr):
     return '({0})'.format(', '.join(formatted))
 
 
-_subtract_one = '{0} - 1'.format
+_subtract_one = '({0} - 1)'.format
 
 
 _expr_transforms = {

--- a/ibis/impala/tests/test_exprs.py
+++ b/ibis/impala/tests/test_exprs.py
@@ -772,7 +772,7 @@ class TestAnalyticFunctions(unittest.TestCase, ExprSQLTest):
 
         cases = [
             (ibis.row_number().over(w),
-             'row_number() OVER (ORDER BY `float_col`) - 1'),
+             '(row_number() OVER (ORDER BY `float_col`) - 1)'),
             (t.string_col.lag(), 'lag(`string_col`)'),
             (t.string_col.lag(2), 'lag(`string_col`, 2)'),
             (t.string_col.lag(default=0), 'lag(`string_col`, 1, 0)'),

--- a/ibis/sql/postgres/compiler.py
+++ b/ibis/sql/postgres/compiler.py
@@ -517,6 +517,7 @@ _operation_registry.update({
     ops.TimestampNow: lambda *args: sa.func.timezone('UTC', sa.func.now()),
     ops.WindowOp: _window,
     ops.CumulativeOp: _window,
+    ops.RowNumber: fixed_arity(lambda: sa.func.row_number(), 0),
 })
 
 

--- a/ibis/sql/postgres/tests/test_functions.py
+++ b/ibis/sql/postgres/tests/test_functions.py
@@ -618,3 +618,13 @@ class TestPostgreSQLFunctions(PostgreSQLTests, unittest.TestCase):
             ignore_index=True
         )
         tm.assert_frame_equal(result, expected)
+
+    def test_window_with_arithmetic(self):
+        t = self.alltypes
+        w = ibis.window(order_by=t.timestamp_col)
+        expr = t.mutate(new_col=ibis.row_number().over(w) / 2)
+
+        df = t.projection(['timestamp_col']).sort_by('timestamp_col').execute()
+        expected = df.assign(new_col=[x / 2 for x in range(len(df))])
+        result = expr['timestamp_col', 'new_col'].execute()
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Also adds an implementation of `row_number()` for the postgres backend

Closes #868 