### PR TITLE
Marking connection as not released

### DIFF
--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -145,6 +145,7 @@ class ImpalaConnection(object):
             if (cur.database != self.database or
                     cur.options != self.options):
                 cur = self._new_cursor()
+            cur.released = False
 
             return cur
         except queue.Empty:

--- a/ibis/impala/tests/test_client.py
+++ b/ibis/impala/tests/test_client.py
@@ -355,3 +355,13 @@ LIMIT 10"""
         left.join(right, ['id'])
         left.join(right, ['id', 'name'])
         left.join(right, ['id', 'files'])
+
+    def test_rerelease_cursor(self):
+        with self.con.raw_sql('select 1', True) as cur1:
+            pass
+        with self.con.raw_sql('select 1', True) as cur2:
+            pass
+        with self.con.raw_sql('select 1', True) as cur3:
+            pass
+        assert cur1 == cur2
+        assert cur2 == cur3


### PR DESCRIPTION
https://github.com/cloudera/ibis/issues/871

When a connection is removed from the connection pool, mark released as False as it is no longer released.