### PR TITLE
ENH: Add preliminary support for dates, focusing on Postgres

### DIFF
--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -241,6 +241,10 @@ class String(Variadic):
     pass
 
 
+class Date(Primitive):
+    pass
+
+
 class Timestamp(Primitive):
     pass
 
@@ -426,6 +430,7 @@ int64 = Int64()
 float = Float()
 double = Double()
 string = String()
+date = Date()
 timestamp = Timestamp()
 
 
@@ -440,6 +445,7 @@ _primitive_types = {
     'float': float,
     'double': double,
     'string': string,
+    'date': date,
     'timestamp': timestamp
 }
 

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -428,6 +428,8 @@ class Literal(ValueNode):
             klass = StringScalar
         elif isinstance(self.value, datetime.datetime):
             klass = TimestampScalar
+        elif isinstance(self.value, datetime.date):
+            klass = DateScalar
         else:
             raise com.InputTypeError(self.value)
 
@@ -824,6 +826,30 @@ class DecimalValue(NumericValue):
         return constructor
 
 
+class DateValue(AnyValue):
+
+    _typename = 'date'
+
+    def _can_implicit_cast(self, arg):
+        op = arg.op()
+        if isinstance(op, Literal):
+            try:
+                import pandas as pd
+                pd.Timestamp(op.value)
+                return True
+            except ValueError:
+                return False
+        return False
+
+    def _can_compare(self, other):
+        return isinstance(other, DateValue)
+
+    def _implicit_cast(self, arg):
+        # assume we've checked this is OK at this point...
+        op = arg.op()
+        return DateScalar(op)
+
+
 class TimestampValue(AnyValue):
 
     _typename = 'timestamp'
@@ -924,6 +950,14 @@ class StringScalar(ScalarExpr, StringValue):
 
 
 class StringArray(ArrayExpr, StringValue):
+    pass
+
+
+class DateScalar(ScalarExpr, DateValue):
+    pass
+
+
+class DateArray(ArrayExpr, DateValue):
     pass
 
 

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -48,6 +48,8 @@ _ibis_type_to_sqla = {
 
     dt.String: sa.String,
 
+    dt.Date: sa.Date,
+
     dt.Timestamp: sa.DateTime,
 
     dt.Decimal: sa.NUMERIC,
@@ -66,6 +68,7 @@ _sqla_type_mapping = {
     sa.REAL: dt.Float,
     sa.VARCHAR: dt.String,
     sa.Float: dt.Double,
+    sa.DATE: dt.Date,
 
     sa.types.TEXT: dt.String,
     sa.types.NullType: dt.Null,


### PR DESCRIPTION
This (currently) small PR adds new `Date` datatypes to Ibis and opens to road to make them work with Postgres. The main motivation is that I have some tables with date columns on Redshift, and I'd like them to work :)

I'm not sure whether this is the right approach or not, so please comment away!