### PR TITLE
BUG: Enable cursors to be re-released to the connection pool

### DIFF
--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -146,6 +146,7 @@ class ImpalaConnection(object):
             if (cur.database != self.database or
                     cur.options != self.options):
                 cur = self._new_cursor()
+            cur.released = False
 
             return cur
         except queue.Empty:

--- a/ibis/impala/tests/test_client.py
+++ b/ibis/impala/tests/test_client.py
@@ -355,3 +355,13 @@ LIMIT 10"""
         left.join(right, ['id'])
         left.join(right, ['id', 'name'])
         left.join(right, ['id', 'files'])
+
+    def test_rerelease_cursor(self):
+        with self.con.raw_sql('select 1', True) as cur1:
+            pass
+        with self.con.raw_sql('select 1', True) as cur2:
+            pass
+        with self.con.raw_sql('select 1', True) as cur3:
+            pass
+        assert cur1 == cur2
+        assert cur2 == cur3

--- a/ibis/impala/tests/test_client.py
+++ b/ibis/impala/tests/test_client.py
@@ -357,11 +357,20 @@ LIMIT 10"""
         left.join(right, ['id', 'files'])
 
     def test_rerelease_cursor(self):
-        with self.con.raw_sql('select 1', True) as cur1:
+        con = connect_test(self.env)
+
+        with con.raw_sql('select 1', True) as cur1:
             pass
-        with self.con.raw_sql('select 1', True) as cur2:
+
+        cur1.release()
+
+        with con.raw_sql('select 1', True) as cur2:
             pass
-        with self.con.raw_sql('select 1', True) as cur3:
+
+        cur2.release()
+
+        with con.raw_sql('select 1', True) as cur3:
             pass
+
         assert cur1 == cur2
         assert cur2 == cur3

--- a/ibis/impala/tests/test_ddl.py
+++ b/ibis/impala/tests/test_ddl.py
@@ -530,6 +530,13 @@ class TestDDLE2E(ImpalaE2E, unittest.TestCase):
         cls.con.drop_table(cls.table_name, database=cls.tmp_db)
         ImpalaE2E.teardown_e2e(cls)
 
+    def setUp(self):
+        ImpalaE2E.setUp(self)
+
+    def tearDown(self):
+        ImpalaE2E.tearDown(self)
+        gc.collect()
+
     def test_list_databases(self):
         assert len(self.con.list_databases()) > 0
 
@@ -1028,15 +1035,13 @@ class TestDDLE2E(ImpalaE2E, unittest.TestCase):
         table = self.con.delimited_file(hdfs_path, schema, name=name,
                                         database=self.tmp_db,
                                         delimiter=',')
-        try:
-            expr = (table
-                    [table.bar > 0]
-                    .group_by('foo')
-                    .aggregate([table.bar.sum().name('sum(bar)'),
-                                table.baz.sum().name('mean(baz)')]))
-            expr.execute()
-        finally:
-            self.con.drop_table(name, database=self.tmp_db)
+
+        expr = (table
+                [table.bar > 0]
+                .group_by('foo')
+                .aggregate([table.bar.sum().name('sum(bar)'),
+                            table.baz.sum().name('mean(baz)')]))
+        expr.execute()
 
     def test_varchar_char_support(self):
         statement = """\


### PR DESCRIPTION
Closes #871 
Closes #872 

Original note from @maxmzkr "When a connection is removed from the connection pool, mark released as False as it is no longer released."