### PR TITLE
Fixed an issue where connections weren't being closed

### DIFF
--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -93,6 +93,7 @@ class ImpalaConnection(object):
         """
         Close all open Impyla sessions
         """
+        self.reset_connection_pool()
 
     def reset_connection_pool(self):
         if self._connections is not None:


### PR DESCRIPTION
https://github.com/cloudera/ibis/pull/875 Introduced a problem where the cursor connections in the connection pool were no longer being released on the impala connection close. This adds back that functionality.