### PR TITLE
There is a new exception for already closed

### DIFF
--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -205,7 +205,7 @@ class ImpalaCursor(object):
             self._cursor.close()
         except HS2Error as e:
             # connection was closed elsewhere
-            if 'invalid session' not in e.args[0].lower():
+            if 'invalid query handle' not in e.args[0].lower():
                 raise
 
     def __enter__(self):

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -205,7 +205,14 @@ class ImpalaCursor(object):
             self._cursor.close()
         except HS2Error as e:
             # connection was closed elsewhere
-            if 'invalid query handle' not in e.args[0].lower():
+            already_closed_messages = [
+                'invalid query handle',
+                'invalid session',
+            ]
+            for message in already_closed_messages:
+                if message in e.args[0].lower():
+                    break
+            else:
                 raise
 
     def __enter__(self):


### PR DESCRIPTION
If I understand what is supposed to happen here, it looks like the message has been updated.
```
Traceback (most recent call last):
  File "/pipedream/local/venv/deepfield-env/lib/python2.7/site-packages/ibis/impala/client.py", line 206, in _close_cursor
    self._cursor.close()
  File "/pipedream/local/venv/deepfield-env/lib/python2.7/site-packages/impala/hiveserver2.py", line 197, in close
    self.close_operation()
  File "/pipedream/local/venv/deepfield-env/lib/python2.7/site-packages/impala/hiveserver2.py", line 212, in close_operation
    self._reset_state()
  File "/pipedream/local/venv/deepfield-env/lib/python2.7/site-packages/impala/hiveserver2.py", line 221, in _reset_state
    self._last_operation.close()
  File "/pipedream/local/venv/deepfield-env/lib/python2.7/site-packages/impala/hiveserver2.py", line 1017, in close
    self._rpc('CloseOperation', req)
  File "/pipedream/local/venv/deepfield-env/lib/python2.7/site-packages/impala/hiveserver2.py", line 817, in _rpc
    err_if_rpc_not_ok(response)
  File "/pipedream/local/venv/deepfield-env/lib/python2.7/site-packages/impala/hiveserver2.py", line 604, in err_if_rpc_not_ok
    raise HiveServer2Error(resp.status.errorMessage)
HiveServer2Error: Invalid query handle
```

It's causing this message to show up
```
Exception impala.error.HiveServer2Error: HiveServer2Error('Invalid query handle',) in <bound method ImpalaCursor.__del__ of <ibis.impala.client.ImpalaCursor object at 0x7f367c044710>> ignored
```

I can have it allow both messages if that makes more sense.