### PR TITLE
Pin to <= 2.9.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest<=2.9.2
 numpy>=1.7.0
 pandas>=0.12.0
 impyla>=0.13.7


### PR DESCRIPTION
https://github.com/pytest-dev/pytest/issues/1889

pytest >= 3.0 introduced a bug where conftest is being loaded multiple times. This is causing the tests to fail to run.