### PR TITLE
ENH: cache subtree comparison and short circuit with id

### DIFF
--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -95,7 +95,7 @@ class Schema(object):
         types = values.values()
         return Schema(names, types)
 
-    def equals(self, other):
+    def equals(self, other, cache=None):
         return self.names == other.names and self.types == other.types
 
     def __eq__(self, other):
@@ -148,10 +148,10 @@ class HasSchema(object):
     def name(self):
         return self._name
 
-    def equals(self, other):
+    def equals(self, other, cache=None):
         if type(self) != type(other):
             return False
-        return self.schema.equals(other.schema)
+        return self.schema.equals(other.schema, cache=cache)
 
     def root_tables(self):
         return [self]
@@ -187,7 +187,7 @@ class DataType(object):
     def name(self):
         return type(self).__name__
 
-    def equals(self, other):
+    def equals(self, other, cache=None):
         if isinstance(other, six.string_types):
             other = validate_type(other)
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1613,9 +1613,9 @@ class SortKey(ir.Node):
     def to_expr(self):
         return ir.SortExpr(self)
 
-    def equals(self, other):
+    def equals(self, other, cache=None):
         return (isinstance(other, SortKey) and
-                self.expr.equals(other.expr) and
+                self.expr.equals(other.expr, cache=cache) and
                 self.ascending == other.ascending)
 
 

--- a/ibis/expr/temporal.py
+++ b/ibis/expr/temporal.py
@@ -84,7 +84,7 @@ class Timedelta(object):
         klass = type(self)
         return klass(self.n + other.n)
 
-    def equals(self, other):
+    def equals(self, other, cache=None):
         if type(self) != type(other):
             return False
 

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -308,7 +308,6 @@ def all_equal(left, right, cache=None):
     if hasattr(left, 'equals'):
         return left.equals(right, cache=cache)
     else:
-        print type(left), type(right)
         return left == right
     return True
 

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -166,10 +166,10 @@ class Expr(object):
         except:
             return False
 
-    def equals(self, other):
+    def equals(self, other, cache=None):
         if type(self) != type(other):
             return False
-        return self._arg.equals(other._arg)
+        return self._arg.equals(other._arg, cache=cache)
 
     def _can_compare(self, other):
         return False
@@ -252,16 +252,30 @@ class Node(object):
             else:
                 yield arg
 
-    def equals(self, other):
+    def equals(self, other, cache=None):
+        if cache is None:
+            cache = {}
+
+        if (self, other) in cache:
+            return cache[(self, other)]
+
+        if id(self) == id(other):
+            cache[(self, other)] = True
+            return True
+
         if type(self) != type(other):
+            cache[(self, other)] = False
             return False
 
         if len(self.args) != len(other.args):
+            cache[(self, other)] = False
             return False
 
         for left, right in zip(self.args, other.args):
-            if not all_equal(left, right):
+            if not all_equal(left, right, cache=cache):
+                cache[(self, other)] = False
                 return False
+        cache[(self, other)] = True
         return True
 
     def is_ancestor(self, other):
@@ -282,18 +296,19 @@ class Node(object):
         raise NotImplementedError
 
 
-def all_equal(left, right):
+def all_equal(left, right, cache=None):
     if isinstance(left, list):
         if not isinstance(right, list):
             return False
         for a, b in zip(left, right):
-            if not all_equal(a, b):
+            if not all_equal(a, b, cache=cache):
                 return False
         return True
 
     if hasattr(left, 'equals'):
-        return left.equals(right)
+        return left.equals(right, cache=cache)
     else:
+        print type(left), type(right)
         return left == right
     return True
 
@@ -409,7 +424,7 @@ class Literal(ValueNode):
     def args(self):
         return [self.value]
 
-    def equals(self, other):
+    def equals(self, other, cache=None):
         if not isinstance(other, Literal):
             return False
         return (isinstance(other.value, type(self.value)) and
@@ -463,14 +478,14 @@ class ValueExpr(Expr):
         Expr.__init__(self, arg)
         self._name = name
 
-    def equals(self, other):
+    def equals(self, other, cache=None):
         if not isinstance(other, ValueExpr):
             return False
 
         if self._name != other._name:
             return False
 
-        return Expr.equals(self, other)
+        return Expr.equals(self, other, cache=cache)
 
     def type(self):
         import ibis.expr.datatypes as dt
@@ -1125,7 +1140,7 @@ class NullLiteral(ValueNode):
     def args(self):
         return [self.value]
 
-    def equals(self, other):
+    def equals(self, other, cache=None):
         return isinstance(other, NullLiteral)
 
     def output_type(self):

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -124,20 +124,35 @@ class Window(object):
         new_sorts = self._order_by + util.promote_list(expr)
         return self._replace(order_by=new_sorts)
 
-    def equals(self, other):
+    def equals(self, other, cache=None):
+        if cache is None:
+            cache = {}
+
+        if (self, other) in cache:
+            return cache[(self, other)]
+
+        if id(self) == id(other):
+            cache[(self, other)] = True
+            return True
+
         if not isinstance(other, Window):
+            cache[(self, other)] = False
             return False
 
         if (len(self._group_by) != len(other._group_by) or
-                not ir.all_equal(self._group_by, other._group_by)):
+                not ir.all_equal(self._group_by, other._group_by, cache=cache)):
+            cache[(self, other)] = False
             return False
 
         if (len(self._order_by) != len(other._order_by) or
-                not ir.all_equal(self._order_by, other._order_by)):
+                not ir.all_equal(self._order_by, other._order_by, cache=cache)):
+            cache[(self, other)] = False
             return False
 
-        return (self.preceding == other.preceding and
+        equal = (self.preceding == other.preceding and
                 self.following == other.following)
+        cache[(self, other)] = equal
+        return equal
 
 
 def window(preceding=None, following=None, group_by=None, order_by=None):

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -1308,20 +1308,34 @@ class Select(DDL):
                                      permit_subquery=permit_subquery)
         return translator.get_result()
 
-    def equals(self, other):
+    def equals(self, other, cache=None):
+        if cache is None:
+            cache = {}
+
+        if (self, other) in cache:
+            return cache[(self, other)]
+
+        if id(self) == id(other):
+            cache[(self, other)] = True
+            return True
+
         if not isinstance(other, Select):
+            cache[(self, other)] = False
             return False
 
         this_exprs = self._all_exprs()
         other_exprs = other._all_exprs()
 
         if self.limit != other.limit:
+            cache[(self, other)] = False
             return False
 
         for x, y in zip(this_exprs, other_exprs):
             if not x.equals(y):
+                cache[(self, other)] = False
                 return False
 
+        cache[(self, other)] = True
         return True
 
     def _all_exprs(self):


### PR DESCRIPTION
This caches whether lower parts of the DAG are equal so when they are compared again we don't have to recompare every node in the DAG

```
    A             A'
   / \           / \
  B   C         B'  C'
   \ /           \ /
    D             D'
   / \           / \
  E   F         E'  F'
   \ /           \ /
    G             G'

```
Comparing A to A' would end up comparing G to G' 4 times. With the caching, we compare every node to every other node at most once.

I also added an short circuit with id's. Any two nodes with the same id must be equal so there is no need to compare it's descendants.


```python
import ibis


def _and(x, y):
    return x & y


def main():
    src_table = ibis.table((('_timestamp', 'int32'),
                            ('dim1', 'int32'),
                            ('dim2', 'int32'),
                            ('valid_seconds', 'int32'),
                            ('meas1', 'int32'),
                            ('meas2', 'int32'),
                            ('year', 'int32'),
                            ('month', 'int32'),
                            ('day', 'int32'),
                            ('hour', 'int32'),
                            ('minute', 'int32'), ), name='src_table')
    src_table_bound = (
        (src_table['year'] > 2016) | (
            (src_table['year'] == 2016) & (src_table['month'] > 6)) | (
                (src_table['year'] == 2016) & (src_table['month'] == 6) &
                (src_table['day'] > 6)) | (
                    (src_table['year'] == 2016) & (src_table['month'] == 6) &
                    (src_table['day'] == 6) & (src_table['hour'] > 6)) |
        ((src_table['year'] == 2016) & (src_table['month'] == 6) &
         (src_table['day'] == 6) & (src_table['hour'] == 6) &
         (src_table['minute'] >= 5))) & ((src_table['year'] < 2016) | (
             (src_table['year'] == 2016) & (src_table['month'] < 6)) | (
                 (src_table['year'] == 2016) & (src_table['month'] == 6) &
                 (src_table['day'] < 6)) | (
                     (src_table['year'] == 2016) & (src_table['month'] == 6) &
                     (src_table['day'] == 6) & (src_table['hour'] < 6)) | (
                         (src_table['year'] == 2016) &
                         (src_table['month'] == 6) & (src_table['day'] == 6) &
                         (src_table['hour'] == 6) &
                         (src_table['minute'] <= 5)))

    src_table = src_table[src_table_bound]
    src_table = src_table.mutate(_timestamp=(
        src_table['_timestamp'] - src_table['_timestamp'] % 3600
    ).cast('int32').name('_timestamp'), valid_seconds=300)

    aggs = []
    for meas in ['meas1', 'meas2']:
        aggs.append(src_table[meas].sum().cast('float').name(meas))
    src_table = src_table.aggregate(
        aggs, by=['_timestamp', 'dim1', 'dim2', 'valid_seconds'])

    part_keys = ['year', 'month', 'day', 'hour', 'minute']
    ts_col = src_table['_timestamp'].cast('timestamp')
    new_cols = {}
    for part_key in part_keys:
        part_col = getattr(ts_col, part_key)()
        new_cols[part_key] = part_col
    src_table = src_table.mutate(**new_cols)

    src_table = src_table[['_timestamp', 'dim1', 'dim2', 'meas1', 'meas2',
                           'year', 'month', 'day', 'hour', 'minute']]

    ibis.impala.compile(src_table)


if __name__ == "__main__":
    main()
```

```
(ibis) max@WORKY:~/ibis (master)$ time python test.py 

real    0m6.416s
user    0m6.352s
sys     0m0.368s
(ibis) max@WORKY:~/ibis (master)$ git checkout fast-equals
Switched to branch 'fast-equals'
Your branch is up-to-date with 'origin/fast-equals'.
(ibis) max@WORKY:~/ibis (fast-equals)$ time python test.py                                                                                                                                         
real    0m4.392s
user    0m4.280s
sys     0m0.420s
```

30% faster. Time saving is in the
```
    src_table = src_table[['_timestamp', 'dim1', 'dim2', 'meas1', 'meas2',
                           'year', 'month', 'day', 'hour', 'minute']]
```