### PR TITLE
ENH: Faster compiling

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -390,6 +390,8 @@ def cast(arg, target_type):
         return arg
     else:
         result = op.to_expr()
+        if not arg.has_name():
+            return result
         try:
             expr_name = ('cast({0}, {1!s})'
                          .format(arg.get_name(),

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -42,9 +42,11 @@ class FormatMemo(object):
         return result
 
     def _format(self, obj):
-        return obj._repr(memo=self._repr_memo)
+        return obj._repr(memo=self)
 
-    def observe(self, obj, formatter=lambda x: x._repr()):
+    def observe(self, obj, formatter=None):
+        if formatter is None:
+            formatter = self._format
         key = self._key(obj)
         if key not in self.formatted:
             self.aliases[key] = 'ref_%d' % len(self.formatted)
@@ -103,7 +105,7 @@ class ExprFormatter(object):
             text = self._format_column(self.expr)
         elif isinstance(what, ir.Node):
             text = self._format_node(what)
-        elif isinstance(what, ops.Literal):
+        elif isinstance(what, ir.Literal):
             text = 'Literal[%s] %s' % (self._get_type_display(),
                                        str(what.value))
 

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -890,7 +890,6 @@ class QueryBuilder(object):
     def _make_context(self):
         raise NotImplementedError
 
-
     def get_result(self):
         op = self.expr.op()
 

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -21,6 +21,7 @@ import ibis.expr.analytics as analytics
 
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
+import ibis.expr.format
 
 import ibis.sql.transforms as transforms
 import ibis.util as util
@@ -889,6 +890,7 @@ class QueryBuilder(object):
     def _make_context(self):
         raise NotImplementedError
 
+
     def get_result(self):
         op = self.expr.op()
 
@@ -918,7 +920,7 @@ class QueryContext(object):
     Records bits of information used during ibis AST to SQL translation
     """
 
-    def __init__(self, indent=2, parent=None):
+    def __init__(self, indent=2, parent=None, memo=None):
         self._table_refs = {}
         self.extracted_subexprs = set()
         self.subquery_memo = {}
@@ -930,6 +932,7 @@ class QueryContext(object):
         self.query = None
 
         self._table_key_memo = {}
+        self.memo = memo or ibis.expr.format.FormatMemo()
 
     def _compile_subquery(self, expr, isolated=False):
         sub_ctx = self.subcontext(isolated=isolated)


### PR DESCRIPTION
The compiler memoizes parts of the DAG, there are some places where the memo is lost. This passes it around to more places. There are probably still more places that it can be passed to, but this is all the more I have time for right now.

```python
import cProfile
import ibis


def _and(x, y):
    return x & y


def main():
    src_table = ibis.table((('_timestamp', 'int32'),
                            ('dim1', 'int32'),
                            ('dim2', 'int32'),
                            ('valid_seconds', 'int32'),
                            ('meas1', 'int32'),
                            ('meas2', 'int32'),
                            ('year', 'int32'),
                            ('month', 'int32'),
                            ('day', 'int32'),
                            ('hour', 'int32'),
                            ('minute', 'int32'), ), name='src_table')
    src_table_bound = (
        (src_table['year'] > 2016) | (
            (src_table['year'] == 2016) & (src_table['month'] > 6)) | (
                (src_table['year'] == 2016) & (src_table['month'] == 6) &
                (src_table['day'] > 6)) | (
                    (src_table['year'] == 2016) & (src_table['month'] == 6) &
                    (src_table['day'] == 6) & (src_table['hour'] > 6)) |
        ((src_table['year'] == 2016) & (src_table['month'] == 6) &
         (src_table['day'] == 6) & (src_table['hour'] == 6) &
         (src_table['minute'] >= 5))) & ((src_table['year'] < 2016) | (
             (src_table['year'] == 2016) & (src_table['month'] < 6)) | (
                 (src_table['year'] == 2016) & (src_table['month'] == 6) &
                 (src_table['day'] < 6)) | (
                     (src_table['year'] == 2016) & (src_table['month'] == 6) &
                     (src_table['day'] == 6) & (src_table['hour'] < 6)) | (
                         (src_table['year'] == 2016) &
                         (src_table['month'] == 6) & (src_table['day'] == 6) &
                         (src_table['hour'] == 6) &
                         (src_table['minute'] <= 5)))

    src_table = src_table[src_table_bound]
    src_table = src_table.mutate(_timestamp=(
        src_table['_timestamp'] - src_table['_timestamp'] % 3600
    ).cast('int32').name('_timestamp'), valid_seconds=300)

    aggs = []
    for meas in ['meas1', 'meas2']:
        aggs.append(src_table[meas].sum().cast('float').name(meas))
    src_table = src_table.aggregate(
        aggs, by=['_timestamp', 'dim1', 'dim2', 'valid_seconds'])

    part_keys = ['year', 'month', 'day', 'hour', 'minute']
    ts_col = src_table['_timestamp'].cast('timestamp')
    new_cols = {}
    for part_key in part_keys:
        part_col = getattr(ts_col, part_key)()
        new_cols[part_key] = part_col
    src_table = src_table.mutate(**new_cols)

    src_table = src_table[['_timestamp', 'dim1', 'dim2', 'meas1', 'meas2',
                           'year', 'month', 'day', 'hour', 'minute']]

    ibis.impala.compile(src_table)


if __name__ == "__main__":
    main()
```
```
(ibis) max@WORKY:~/ibis (master)$ time python test.py                                                                                                                                              

real    0m6.453s
user    0m6.400s
sys     0m0.368s
(ibis) max@WORKY:~/ibis (master)$ git checkout fast
Switched to branch 'fast'
Your branch is up-to-date with 'origin/fast'.
(ibis) max@WORKY:~/ibis (fast)$ time python test.py

real    0m3.384s
user    0m3.328s
sys     0m0.372s
```
45% faster