### PR TITLE
BUG: Better tree pruning for complex queries for improved performance

### DIFF
--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -42,7 +42,7 @@ class TableNode(Node):
     def get_type(self, name):
         return self.get_schema().get_type(name)
 
-    def to_expr(self):
+    def _make_expr(self):
         return TableExpr(self)
 
     def aggregate(self, this, metrics, by=None, having=None):
@@ -158,7 +158,7 @@ class TableArrayView(ValueNode):
 
         Node.__init__(self, [table])
 
-    def to_expr(self):
+    def _make_expr(self):
         ctype = self.table._get_type(self.name)
         klass = ctype.array_type()
         return klass(self, name=self.name)
@@ -1610,7 +1610,7 @@ class SortKey(ir.Node):
     def root_tables(self):
         return self.expr._root_tables()
 
-    def to_expr(self):
+    def _make_expr(self):
         return ir.SortExpr(self)
 
     def equals(self, other, cache=None):

--- a/ibis/expr/tests/test_format.py
+++ b/ibis/expr/tests/test_format.py
@@ -74,7 +74,7 @@ class TestExprFormatting(unittest.TestCase):
         formatter = ExprFormatter(result)
         formatted = formatter.get_result()
 
-        alias = formatter.memo.get_alias(table.op())
+        alias = formatter.memo.get_alias(table)
         assert formatted.count(alias) == 7
 
     def test_aggregate_arg_names(self):

--- a/ibis/expr/tests/test_table.py
+++ b/ibis/expr/tests/test_table.py
@@ -266,7 +266,7 @@ def test_mutate(table):
 
     expr = table.mutate(foo, one=one, two=2)
     expected = table[table, foo, one.name('one'),
-                          ibis.literal(2).name('two')]
+                     ibis.literal(2).name('two')]
     assert_equal(expr, expected)
 
 
@@ -897,7 +897,7 @@ def test_join_compound_boolean_predicate(table):
 
 def test_filter_join_unmaterialized(table):
     table1 = ibis.table({'key1': 'string', 'key2': 'string',
-                        'value1': 'double'})
+                         'value1': 'double'})
     table2 = ibis.table({'key3': 'string', 'value2': 'double'})
 
     # It works!
@@ -1100,7 +1100,7 @@ def test_aggregate_metrics(table):
 
 def test_group_by_keys(table):
     m = table.mutate(foo=table.f * 2,
-                          bar=table.e / 2)
+                     bar=table.e / 2)
 
     expr = m.group_by(lambda x: x.foo).size()
     expected = m.group_by('foo').size()
@@ -1113,7 +1113,7 @@ def test_group_by_keys(table):
 
 def test_having(table):
     m = table.mutate(foo=table.f * 2,
-                          bar=table.e / 2)
+                     bar=table.e / 2)
 
     expr = (m.group_by('foo')
             .having(lambda x: x.foo.sum() > 10)
@@ -1127,7 +1127,7 @@ def test_having(table):
 
 def test_filter(table):
     m = table.mutate(foo=table.f * 2,
-                          bar=table.e / 2)
+                     bar=table.e / 2)
 
     result = m.filter(lambda x: x.foo > 10)
     result2 = m[lambda x: x.foo > 10]

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -209,10 +209,12 @@ class Node(object):
         return self._repr()
 
     def _repr(self, memo=None):
-        # Quick and dirty to get us started
+        if memo is None:
+            from ibis.expr.format import FormatMemo
+            memo = FormatMemo()
+
         opname = type(self).__name__
         pprint_args = []
-
 
         def _pp(x):
             return _safe_repr(x, memo=memo)
@@ -271,7 +273,15 @@ class Node(object):
 
         return self.equals(other)
 
+    _expr_cached = None
+
     def to_expr(self):
+        if self._expr_cached is None:
+            self._expr_cached = self._make_expr()
+        return self._expr_cached
+        # return self._make_expr()
+
+    def _make_expr(self):
         klass = self.output_type()
         return klass(self)
 
@@ -351,7 +361,7 @@ class TableColumn(ValueNode):
     def root_tables(self):
         return self.table._root_tables()
 
-    def to_expr(self):
+    def _make_expr(self):
         ctype = self.table._get_type(self.name)
         klass = ctype.array_type()
         return klass(self, name=self.name)
@@ -1168,7 +1178,7 @@ class ValueList(ValueNode):
     def root_tables(self):
         return distinct_roots(*self.values)
 
-    def to_expr(self):
+    def _make_expr(self):
         return ListExpr(self)
 
 

--- a/ibis/impala/tests/test_window.py
+++ b/ibis/impala/tests/test_window.py
@@ -140,6 +140,7 @@ OVER (ORDER BY `f`) AS `foo`
 FROM alltypes"""
     assert_sql_equal(result, expected)
 
+
 def test_rank_functions(con):
     t = con.table('alltypes')
 
@@ -150,6 +151,7 @@ SELECT `g`, (rank() OVER (ORDER BY `f`) - 1) AS `minr`,
        (dense_rank() OVER (ORDER BY `f`) - 1) AS `denser`
 FROM alltypes"""
     assert_sql_equal(proj, expected)
+
 
 def test_multiple_windows(con):
     t = con.table('alltypes')
@@ -163,6 +165,7 @@ def test_multiple_windows(con):
 SELECT `g`, sum(`f`) OVER (PARTITION BY `g`) - sum(`f`) OVER () AS `result`
 FROM alltypes"""
     assert_sql_equal(proj, expected)
+
 
 def test_order_by_desc(con):
     t = con.table('alltypes')
@@ -183,6 +186,7 @@ SELECT lag(`d`) OVER (PARTITION BY `g` ORDER BY `f` DESC) AS `foo`,
        max(`a`) OVER (PARTITION BY `g` ORDER BY `f` DESC) AS `max`
 FROM alltypes"""
     assert_sql_equal(expr, expected)
+
 
 def test_row_number_requires_order_by(con):
     t = con.table('alltypes')

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -21,7 +21,7 @@ import ibis.expr.analytics as analytics
 
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
-import ibis.expr.format
+import ibis.expr.format as format
 
 import ibis.sql.transforms as transforms
 import ibis.util as util
@@ -931,7 +931,7 @@ class QueryContext(object):
         self.query = None
 
         self._table_key_memo = {}
-        self.memo = memo or ibis.expr.format.FormatMemo()
+        self.memo = memo or format.FormatMemo()
 
     def _compile_subquery(self, expr, isolated=False):
         sub_ctx = self.subcontext(isolated=isolated)


### PR DESCRIPTION
Closes #859. There's still some redundant work happening, but further tweaking can happen in a follow up PR. From the example in #889, we have:

Before this PR:

```
In [2]: %time ibis.impala.compile(src_table)
CPU times: user 2.08 s, sys: 0 ns, total: 2.08 s
Wall time: 2.08 s
```

after:

```
In [2]: %timeit _ = ibis.impala.compile(src_table)
10 loops, best of 3: 57.9 ms per loop
```

This bad compilation performance is pretty vicious, so I think it's time for a 0.9 release. Sound good @cpcloud?
