### PR TITLE
ENH: Extract subqueries into CTEs in UNION queries

### DIFF
--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -412,17 +412,14 @@ class AlchemyContext(comp.QueryContext):
         self.dialect = kwargs.pop('dialect', AlchemyDialect)
         comp.QueryContext.__init__(self, *args, **kwargs)
 
-    def subcontext(self, isolated=False):
-        if not isolated:
-            return type(self)(dialect=self.dialect, parent=self)
-        else:
-            return type(self)(dialect=self.dialect)
+    def subcontext(self):
+        return type(self)(dialect=self.dialect, parent=self)
 
     def _to_sql(self, expr, ctx):
         return to_sqlalchemy(expr, context=ctx)
 
-    def _compile_subquery(self, expr, isolated=False):
-        sub_ctx = self.subcontext(isolated=isolated)
+    def _compile_subquery(self, expr):
+        sub_ctx = self.subcontext()
         return self._to_sql(expr, sub_ctx)
 
     def has_table(self, expr, parent_contexts=False):

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -404,10 +404,8 @@ class SelectBuilder(object):
         self._collect(op.table, toplevel=toplevel)
 
     def _collect_Union(self, expr, toplevel=False):
-        if not toplevel:
-            return
-        else:
-            raise NotImplementedError
+        if toplevel:
+            raise NotImplementedError()
 
     def _collect_Aggregation(self, expr, toplevel=False):
         # The select set includes the grouping keys (if any), and these are
@@ -680,7 +678,9 @@ class _ExtractSubqueries(object):
         self.visit(expr.op().table)
 
     def _visit_Union(self, expr):
-        self.observe(expr)
+        op = expr.op()
+        self.visit(op.left)
+        self.visit(op.right)
 
     def _visit_MaterializedJoin(self, expr):
         self.observe(expr)
@@ -904,7 +904,7 @@ class QueryBuilder(object):
 
     def _make_union(self):
         op = self.expr.op()
-        return self._union_class(op.left, op.right,
+        return self._union_class(op.left, op.right, self.expr,
                                  distinct=op.distinct,
                                  context=self.context)
 
@@ -933,8 +933,8 @@ class QueryContext(object):
         self._table_key_memo = {}
         self.memo = memo or format.FormatMemo()
 
-    def _compile_subquery(self, expr, isolated=False):
-        sub_ctx = self.subcontext(isolated=isolated)
+    def _compile_subquery(self, expr):
+        sub_ctx = self.subcontext()
         return self._to_sql(expr, sub_ctx)
 
     def _to_sql(self, expr, ctx):
@@ -950,7 +950,7 @@ class QueryContext(object):
     def set_always_alias(self):
         self.always_alias = True
 
-    def get_compiled_expr(self, expr, isolated=False):
+    def get_compiled_expr(self, expr):
         this = self.top_context
 
         key = self._get_table_key(expr)
@@ -961,7 +961,7 @@ class QueryContext(object):
         if isinstance(op, ops.SQLQueryResult):
             result = op.query
         else:
-            result = self._compile_subquery(expr, isolated=isolated)
+            result = self._compile_subquery(expr)
 
         this.subquery_memo[key] = result
         return result
@@ -1016,11 +1016,8 @@ class QueryContext(object):
         self.extracted_subexprs.add(key)
         self.make_alias(expr)
 
-    def subcontext(self, isolated=False):
-        if not isolated:
-            return type(self)(indent=self.indent, parent=self)
-        else:
-            return type(self)(indent=self.indent)
+    def subcontext(self):
+        return type(self)(indent=self.indent, parent=self)
 
     # Maybe temporary hacks for correlated / uncorrelated subqueries
 
@@ -1418,10 +1415,10 @@ class TableSetFormatter(object):
 
 class Union(DDL):
 
-    def __init__(self, left_table, right_table, distinct=False,
-                 context=None):
+    def __init__(self, left_table, right_table, expr, distinct=False, context=None):
         self.context = context
         self.left = left_table
         self.right = right_table
-
         self.distinct = distinct
+        self.table_set = expr
+        self.filters = []

--- a/ibis/sql/tests/test_compiler.py
+++ b/ibis/sql/tests/test_compiler.py
@@ -1459,25 +1459,24 @@ GROUP BY 1"""
         expr = join1.union(join2)
         result = to_sql(expr)
         expected = """\
-(WITH t0 AS (
+WITH t0 AS (
   SELECT `a`, `g`, sum(`f`) AS `metric`
   FROM alltypes
   GROUP BY 1, 2
+),
+t1 AS (
+  SELECT t0.*
+  FROM t0
+    INNER JOIN t0 t3
+      ON t0.`g` = t3.`g`
 )
-SELECT t0.*
-FROM t0
-  INNER JOIN t0 t1
-    ON t0.`g` = t1.`g`)
+SELECT *
+FROM t1
 UNION ALL
-(WITH t0 AS (
-  SELECT `a`, `g`, sum(`f`) AS `metric`
-  FROM alltypes
-  GROUP BY 1, 2
-)
 SELECT t0.*
 FROM t0
-  INNER JOIN t0 t1
-    ON t0.`g` = t1.`g`)"""
+  INNER JOIN t0 t3
+    ON t0.`g` = t3.`g`"""
         assert result == expected
 
     def test_subquery_factor_correlated_subquery(self):


### PR DESCRIPTION
closes #666

This is a first pass at ripping out subqueries in set operations
and putting them into CTEs.

I think there's some additional room for improvement after this PR.

It feels like we could combine all `SELECT`, `UNION`, etc. compilation under a
common base class that conforms to the API that subquery extraction needs and then
implement a few methods for anything special the specific operation might need to
do.