### PR TITLE
ENH: Add array operations

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,9 +35,9 @@ database:
     # dump the data to a CSV file
     - sqlite3 -separator ',' -csv -noheader $IBIS_TEST_SQLITE_DB_PATH <<< 'SELECT * FROM functional_alltypes;' > dump.csv
 
-    # create the Postgres table
+    # create the Postgres tables
     - >
-      psql -U ubuntu -d circle_test <<EOF
+      psql -U ubuntu -d $IBIS_TEST_POSTGRES_DB <<EOF
         CREATE TABLE functional_alltypes (
           "index" BIGINT,
           other BIGINT,
@@ -59,8 +59,27 @@ database:
       EOF
 
     # load the sqlite dump into the pg table
-    - cat dump.csv | psql -U ubuntu -d circle_test -c "COPY functional_alltypes FROM STDIN WITH (FORMAT CSV, HEADER FALSE, DELIMITER ',')"
+    - cat dump.csv | psql -U ubuntu -d $IBIS_TEST_POSTGRES_DB -c "COPY functional_alltypes FROM STDIN WITH (FORMAT CSV, HEADER FALSE, DELIMITER ',')"
     - rm dump.csv
+
+    - >
+      psql -U ubuntu -d $IBIS_TEST_POSTGRES_DB <<EOF
+        CREATE TABLE array_types (
+          x BIGINT[],
+          y TEXT[],
+          z FLOAT8[],
+          grouper TEXT,
+          scalar_column float8
+        );
+
+        INSERT INTO array_types VALUES
+          (ARRAY[1, 2, 3], ARRAY['a', 'b', 'c'], ARRAY[1.0, 2.0, 3.0], 'a', 1.0),
+          (ARRAY[4, 5], ARRAY['d', 'e'], ARRAY[4.0, 5.0], 'a', 2.0),
+          (ARRAY[6, NULL], ARRAY['f', NULL], ARRAY[6.0, NULL], 'a', 3.0),
+          (ARRAY[NULL, 1, NULL], ARRAY[NULL, 'a', NULL], ARRAY[]::float8[], 'b', 4.0),
+          (ARRAY[2, NULL, 3], ARRAY['b', NULL, 'c'], NULL, 'b', 5.0),
+          (ARRAY[4, NULL, NULL, 5], ARRAY['d', NULL, NULL, 'e'], ARRAY[4.0, NULL, NULL, 5.0], 'c', 6.0);
+      EOF
 
 test:
   override:

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -31,6 +31,7 @@ from ibis.expr.types import (Expr,  # noqa
                              StringValue, StringScalar, StringArray,
                              DecimalValue, DecimalScalar, DecimalArray,
                              TimestampValue, TimestampScalar, TimestampArray,
+                             ArrayValue, ArrayScalar, ArrayArray,
                              CategoryValue, unnamed, as_value_expr, literal,
                              null, sequence)
 
@@ -797,7 +798,8 @@ _generic_value_methods = dict(
     __ge__=_binop_expr('__ge__', _ops.GreaterEqual),
     __gt__=_binop_expr('__gt__', _ops.Greater),
     __le__=_binop_expr('__le__', _ops.LessEqual),
-    __lt__=_binop_expr('__lt__', _ops.Less)
+    __lt__=_binop_expr('__lt__', _ops.Less),
+    collect=_unary_op('any', _ops.ArrayCollect),
 )
 
 
@@ -1586,6 +1588,15 @@ _string_value_methods = dict(
 
 
 _add_methods(StringValue, _string_value_methods)
+
+
+# ---------------------------------------------------------------------
+# Array API
+_array_value_methods = dict(
+    length=_unary_op('length', _ops.ArrayLength),
+)
+
+_add_methods(ArrayValue, _array_value_methods)
 
 
 # ---------------------------------------------------------------------

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -799,7 +799,7 @@ _generic_value_methods = dict(
     __gt__=_binop_expr('__gt__', _ops.Greater),
     __le__=_binop_expr('__le__', _ops.LessEqual),
     __lt__=_binop_expr('__lt__', _ops.Less),
-    collect=_unary_op('any', _ops.ArrayCollect),
+    collect=_unary_op('collect', _ops.ArrayCollect),
 )
 
 
@@ -1619,8 +1619,8 @@ def _array_slice(array, index):
 _array_array_methods = dict(
     length=_unary_op('length', _ops.ArrayLength),
     __getitem__=_array_slice,
-    __add__=lambda *args, **kwargs: _ops.ArrayConcat(*args, **kwargs).to_expr(),
-    __mul__=lambda *args, **kwargs: _ops.ArrayRepeat(*args, **kwargs).to_expr(),
+    __add__=_binop_expr('__add__', _ops.ArrayConcat),
+    __mul__=_binop_expr('__mul__', _ops.ArrayRepeat),
 )
 
 _add_methods(ArrayValue, _array_array_methods)

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import six
+import toolz
 
 from ibis.expr.datatypes import Schema  # noqa
 from ibis.expr.types import (Expr,  # noqa
@@ -1620,7 +1621,9 @@ _array_array_methods = dict(
     length=_unary_op('length', _ops.ArrayLength),
     __getitem__=_array_slice,
     __add__=_binop_expr('__add__', _ops.ArrayConcat),
+    __radd__=toolz.flip(_binop_expr('__radd__', _ops.ArrayConcat)),
     __mul__=_binop_expr('__mul__', _ops.ArrayRepeat),
+    __rmul__=_binop_expr('__rmul__', _ops.ArrayRepeat),
 )
 
 _add_methods(ArrayValue, _array_array_methods)

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1617,7 +1617,7 @@ def _array_slice(array, index):
 
 
 _array_array_methods = dict(
-    length=lambda *args, **kwargs: _ops.ArrayLength(*args, **kwargs).to_expr(),#_unary_op('length', _ops.ArrayLength),
+    length=_unary_op('length', _ops.ArrayLength),
     __getitem__=_array_slice,
     __add__=lambda *args, **kwargs: _ops.ArrayConcat(*args, **kwargs).to_expr(),
     __mul__=lambda *args, **kwargs: _ops.ArrayRepeat(*args, **kwargs).to_expr(),

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -451,6 +451,9 @@ class Array(Variadic):
             self.value_type == other.value_type
         )
 
+    def equals(self, other, cache=None):
+        return self == other
+
 
 @parametric
 class Enum(DataType):

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -235,11 +235,10 @@ class Integer(Primitive):
         return lower, upper
 
     def can_implicit_cast(self, other):
-        if isinstance(other, Integer):
-            return ((type(self) == Integer) or
-                    (other._nbytes <= self._nbytes))
-        else:
-            return False
+        return (
+            isinstance(other, Integer) and
+            (type(self) is Integer or other._nbytes <= self._nbytes)
+        )
 
 
 class String(Variadic):

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -309,13 +309,15 @@ def parametric(cls):
     def array_type(self):
         def constructor(op, name=None):
             import ibis.expr.types as ir
-            return getattr(ir, array_type_name)(op, self, name=name)
+            return getattr(ir, array_type_name)(op, self.value_type, name=name)
         return constructor
 
     def scalar_type(self):
         def constructor(op, name=None):
             import ibis.expr.types as ir
-            return getattr(ir, scalar_type_name)(op, self, name=name)
+            return getattr(ir, scalar_type_name)(
+                op, self.value_type, name=name
+            )
         return constructor
 
     cls.array_type = array_type

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -451,9 +451,6 @@ class Array(Variadic):
             self.value_type == other.value_type
         )
 
-    def equals(self, other, cache=None):
-        return self == other
-
 
 @parametric
 class Enum(DataType):

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -227,6 +227,13 @@ class Boolean(Primitive):
 
 class Integer(Primitive):
 
+    @property
+    def bounds(self):
+        exp = self._nbytes * 8 - 1
+        lower = -1 << exp
+        upper = ~lower
+        return lower, upper
+
     def can_implicit_cast(self, other):
         if isinstance(other, Integer):
             return ((type(self) == Integer) or
@@ -266,25 +273,21 @@ class Floating(Primitive):
 class Int8(Integer):
 
     _nbytes = 1
-    bounds = (-128, 127)
 
 
 class Int16(Integer):
 
     _nbytes = 2
-    bounds = (-32768, 32767)
 
 
 class Int32(Integer):
 
     _nbytes = 4
-    bounds = (-2147483648, 2147483647)
 
 
 class Int64(Integer):
 
     _nbytes = 8
-    bounds = (-9223372036854775808, 9223372036854775807)
 
 
 class Float(Floating):
@@ -303,7 +306,7 @@ class Decimal(DataType):
     def __init__(self, precision, scale, nullable=True):
         self.precision = precision
         self.scale = scale
-        DataType.__init__(self, nullable=nullable)
+        super(Decimal, self).__init__(nullable=nullable)
 
     def __repr__(self):
         return '{0}(precision={1:d}, scale={2:d})'.format(

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -18,7 +18,6 @@ from collections import namedtuple, OrderedDict
 
 import six
 
-import ibis.expr.types as ir
 import ibis.common as com
 import ibis.util as util
 
@@ -198,12 +197,12 @@ class DataType(object):
         return self.equals(other)
 
     def scalar_type(self):
-        name = type(self).__name__
-        return getattr(ir, '{0}Scalar'.format(name))
+        import ibis.expr.types as ir
+        return getattr(ir, '{0}Scalar'.format(type(self).__name__))
 
     def array_type(self):
-        name = type(self).__name__
-        return getattr(ir, '{0}Array'.format(name))
+        import ibis.expr.types as ir
+        return getattr(ir, '{0}Array'.format(type(self).__name__))
 
 
 class Any(DataType):
@@ -306,9 +305,6 @@ class Decimal(DataType):
         self.scale = scale
         DataType.__init__(self, nullable=nullable)
 
-    def _base_type(self):
-        return 'decimal'
-
     def __repr__(self):
         return '{0}(precision={1:d}, scale={2:d})'.format(
             self.name,
@@ -358,9 +354,6 @@ class Category(DataType):
     def __init__(self, cardinality=None, nullable=True):
         self.cardinality = cardinality
         DataType.__init__(self, nullable=nullable)
-
-    def _base_type(self):
-        return 'category'
 
     def __repr__(self):
         card = (self.cardinality if self.cardinality is not None

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -309,15 +309,13 @@ def parametric(cls):
     def array_type(self):
         def constructor(op, name=None):
             import ibis.expr.types as ir
-            return getattr(ir, array_type_name)(op, self.value_type, name=name)
+            return getattr(ir, array_type_name)(op, self.meta, name=name)
         return constructor
 
     def scalar_type(self):
         def constructor(op, name=None):
             import ibis.expr.types as ir
-            return getattr(ir, scalar_type_name)(
-                op, self.value_type, name=name
-            )
+            return getattr(ir, scalar_type_name)(op, self.meta, name=name)
         return constructor
 
     cls.array_type = array_type

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -309,13 +309,13 @@ def parametric(cls):
     def array_type(self):
         def constructor(op, name=None):
             import ibis.expr.types as ir
-            return getattr(ir, array_type_name)(op, self.meta, name=name)
+            return getattr(ir, array_type_name)(op, self, name=name)
         return constructor
 
     def scalar_type(self):
         def constructor(op, name=None):
             import ibis.expr.types as ir
-            return getattr(ir, scalar_type_name)(op, self.meta, name=name)
+            return getattr(ir, scalar_type_name)(op, self, name=name)
         return constructor
 
     cls.array_type = array_type

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2379,9 +2379,14 @@ def _array_concat_output_type(self):
     CAST(T AS U) is a valid operation? Postgres allows this for numeric types.
     """
     left, right = self.args[:2]
-    if left.type() != right.type():
-        raise TypeError('Array types must match exactly to concatenate')
-    return left.type()
+    left_type = left.type()
+    right_type = right.type()
+    if left_type != right_type:
+        raise TypeError(
+            'Array types must match exactly to concatenate. '
+            'Left type {} != Right type {}'.format(left_type, right_type)
+        )
+    return left_type
 
 
 class ArrayConcat(ValueOp):

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2368,23 +2368,19 @@ class ArrayIndex(ValueOp):
     )
 
 
-def _array_concat_output_type(self):
-    """Find the leaf type of each of the left and right arrays in a concat
-    operation and build an output type respecting the nesting level of the
-    original array.
-
-    Notes
-    -----
-    What do other systems do when casting ARRAY<T> to ARRAY<U> where
-    CAST(T AS U) is a valid operation? Postgres allows this for numeric types.
+def _array_binop_invariant_output_type(self):
+    """Check whether two arrays in an array OP array binary operation have
+    the same type.
     """
-    left, right = self.args[:2]
-    left_type = left.type()
-    right_type = right.type()
+    args = self.args
+    left_type = args[0].type()
+    right_type = args[1].type()
     if left_type != right_type:
         raise TypeError(
-            'Array types must match exactly to concatenate. '
-            'Left type {} != Right type {}'.format(left_type, right_type)
+            'Array types must match exactly in a {} operation. '
+            'Left type {} != Right type {}'.format(
+                type(self).__name__, left_type, right_type
+            )
         )
     return left_type
 
@@ -2392,7 +2388,7 @@ def _array_concat_output_type(self):
 class ArrayConcat(ValueOp):
 
     input_type = [rules.array_array(dt.any), rules.array_array(dt.any)]
-    output_type = rules.array_output(_array_concat_output_type)
+    output_type = rules.array_output(_array_binop_invariant_output_type)
 
 
 class ArrayRepeat(ValueOp):

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2342,3 +2342,17 @@ class TimestampDelta(ValueOp):
 
     input_type = [rules.timestamp, rules.timedelta(name='offset')]
     output_type = rules.shape_like_arg(0, 'timestamp')
+
+
+class ArrayLength(ValueOp):
+
+    input_type = [rules.array_array(dt.any)]
+    output_type = rules.shape_like_arg(0, 'int64')
+
+
+class ArrayCollect(Reduction):
+
+    input_type = [rules.array]
+    output_type = rules.scalar_output(
+        lambda self: dt.Array(self.args[0].type())
+    )

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2379,10 +2379,8 @@ def _array_concat_output_type(self):
     CAST(T AS U) is a valid operation? Postgres allows this for numeric types.
     """
     left, right = self.args[:2]
-    if not left._can_implicit_cast(right):
-        raise TypeError(
-            "Can't implicitly cast {} to {}".format(left.type(), right.type())
-        )
+    if left.type() != right.type():
+        raise TypeError('Array types must match exactly to concatenate')
     return left.type()
 
 

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -622,6 +622,14 @@ def string(**arg_kwds):
     return ValueTyped(dt.string, 'not string', **arg_kwds)
 
 
+def array_array(value_type):
+    return lambda **arg_kwds: ValueTyped(
+        dt.Array(value_type),
+        'not array with value_type {0}'.format(value_type),
+        **arg_kwds
+    )
+
+
 def boolean(**arg_kwds):
     return ValueTyped(dt.boolean, 'not string', **arg_kwds)
 

--- a/ibis/expr/tests/test_array.py
+++ b/ibis/expr/tests/test_array.py
@@ -1,0 +1,15 @@
+import pytest
+import ibis
+import ibis.expr.datatypes as dt
+
+
+def test_array_literal():
+    x = ibis.literal([1, 2, 3])
+    assert x._arg.value == [1, 2, 3]
+    assert x.type() == dt.Array(dt.int8)
+
+
+def test_array_literal_mixed():
+    x = ibis.literal([1, 2, 3.0])
+    assert x._arg.value == [1, 2, 3.0]
+    assert x.type() == dt.Array(dt.double)

--- a/ibis/expr/tests/test_array.py
+++ b/ibis/expr/tests/test_array.py
@@ -3,13 +3,15 @@ import ibis
 import ibis.expr.datatypes as dt
 
 
-def test_array_literal():
-    x = ibis.literal([1, 2, 3])
-    assert x._arg.value == [1, 2, 3]
-    assert x.type() == dt.Array(dt.int8)
-
-
-def test_array_literal_mixed():
-    x = ibis.literal([1, 2, 3.0])
-    assert x._arg.value == [1, 2, 3.0]
-    assert x.type() == dt.Array(dt.double)
+@pytest.mark.parametrize(
+    ['arg', 'type'],
+    [
+        ([1, 2, 3], dt.Array(dt.int8)),
+        ([1, 2, 3.0], dt.Array(dt.double)),
+        (['a', 'b', 'c'], dt.Array(dt.string))
+    ]
+)
+def test_array_literal(arg, type):
+    x = ibis.literal(arg)
+    assert x._arg.value == arg
+    assert x.type() == type

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -457,7 +457,7 @@ class Literal(ValueNode):
         elif isinstance(value, list):
             value_type = rules.highest_precedence_type(map(literal, value))
             return lambda value, value_type=value_type: ArrayScalar(
-                value, value_type
+                value, dt.Array(value_type)
             )
 
         raise com.InputTypeError(value)
@@ -919,9 +919,9 @@ class TimestampValue(AnyValue):
 
 class ArrayValue(AnyValue):
 
-    def __init__(self, value_type, name=None):
-        super(ArrayValue, self).__init__(value_type)
-        self.value_type = value_type
+    def __init__(self, type, name=None):
+        super(ArrayValue, self).__init__(type.value_type)
+        self.value_type = type.value_type
 
     def type(self):
         return dt.Array(self.value_type)
@@ -1108,7 +1108,7 @@ class ArrayScalar(ArrayValue, ScalarExpr):
     @property
     def _factory(self):
         def factory(arg, name=None):
-            return ArrayScalar(arg, self.type().value_type, name=name)
+            return ArrayScalar(arg, self.type(), name=name)
         return factory
 
 
@@ -1121,7 +1121,7 @@ class ArrayArray(ArrayValue, ArrayExpr):
     @property
     def _factory(self):
         def factory(arg, name=None):
-            return ArrayArray(arg, self.type().value_type, name=name)
+            return ArrayArray(arg, self.type(), name=name)
         return factory
 
 

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -1108,7 +1108,7 @@ class ArrayScalar(ArrayValue, ScalarExpr):
     @property
     def _factory(self):
         def factory(arg, name=None):
-            return ArrayScalar(arg, self.meta, name=name)
+            return ArrayScalar(arg, self.type().value_type, name=name)
         return factory
 
 
@@ -1121,7 +1121,7 @@ class ArrayArray(ArrayValue, ArrayExpr):
     @property
     def _factory(self):
         def factory(arg, name=None):
-            return ArrayArray(arg, self.meta, name=name)
+            return ArrayArray(arg, self.type().value_type, name=name)
         return factory
 
 

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -927,10 +927,10 @@ class ArrayValue(AnyValue):
         return dt.Array(self.value_type)
 
     def _can_implicit_cast(self, arg):
-        return False
+        return self.type().can_implicit_cast(arg.type())
 
     def _can_compare(self, other):
-        return isinstance(other, ListValue)
+        return isinstance(other, ArrayValue)
 
 
 class NumericArray(ArrayExpr, NumericValue):

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -926,9 +926,6 @@ class ArrayValue(AnyValue):
     def type(self):
         return dt.Array(self.value_type)
 
-    def _can_implicit_cast(self, arg):
-        return self.type().can_implicit_cast(arg.type())
-
     def _can_compare(self, other):
         return isinstance(other, ArrayValue)
 

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -88,9 +88,7 @@ def sqlalchemy_type_to_ibis_type(column_type, nullable=True):
             column_type.precision, column_type.scale, nullable=nullable
         )
     else:
-        if column_type in _sqla_type_to_ibis:
-            ibis_class = _sqla_type_to_ibis[column_type]
-        elif type_class in _sqla_type_to_ibis:
+        if type_class in _sqla_type_to_ibis:
             ibis_class = _sqla_type_to_ibis[type_class]
         elif isinstance(column_type, sa.DateTime):
             ibis_class = dt.Timestamp()
@@ -105,12 +103,17 @@ def sqlalchemy_type_to_ibis_type(column_type, nullable=True):
                 value_type, nullable=nullable
             )
         else:
-            for k, v in _sqla_type_to_ibis.items():
-                if isinstance(column_type, type(k)):
-                    ibis_class = v
-                    break
-            else:
-                raise NotImplementedError(column_type)
+            try:
+                ibis_class = next(
+                    v for k, v in _sqla_type_mapping.items()
+                    if isinstance(column_type, k)
+                )
+            except StopIteration:
+                raise NotImplementedError(
+                    'Unable to convert SQLAlchemy type {} to ibis type'.format(
+                        column_type
+                    )
+                )
         return ibis_class(nullable)
 
 

--- a/ibis/sql/postgres/compiler.py
+++ b/ibis/sql/postgres/compiler.py
@@ -518,6 +518,10 @@ _operation_registry.update({
     ops.WindowOp: _window,
     ops.CumulativeOp: _window,
     ops.RowNumber: fixed_arity(lambda: sa.func.row_number(), 0),
+
+    # array operations
+    ops.ArrayLength: fixed_arity(sa.func.cardinality, 1),
+    ops.ArrayCollect: fixed_arity(sa.func.array_agg, 1),
 })
 
 

--- a/ibis/sql/postgres/compiler.py
+++ b/ibis/sql/postgres/compiler.py
@@ -461,15 +461,18 @@ def _array_repeat(t, expr):
     """
     raw, times = map(t.translate, expr.op().args)
 
-    # sqlalchemy uses our column's table in the FROM clause. We need
-    # a simpler less magical expression to workaround this.
+    # SQLAlchemy uses our column's table in the FROM clause. We need a simpler
+    # expression to workaround this.
     array = sa.column(raw.name, type_=raw.type)
+
+    # We still need to prefix the table, so make the column knows its origin
+    array.table = raw.table
 
     array_length = sa.func.cardinality(array)
 
     # sequence from 1 to the total number of elements desired
-    series = sa.func.generate_series(1, times * array_length).alias('i')
-    series_column = sa.column('i', type_=sa.BIGINT)
+    series = sa.func.generate_series(1, times * array_length).alias()
+    series_column = sa.column(series.name, type_=sa.INTEGER)
 
     # if our current index modulo the array's length
     # is a multiple of the array's length, then the index is the array's length

--- a/ibis/sql/postgres/compiler.py
+++ b/ibis/sql/postgres/compiler.py
@@ -465,7 +465,8 @@ def _array_repeat(t, expr):
     # expression to workaround this.
     array = sa.column(raw.name, type_=raw.type)
 
-    # We still need to prefix the table, so make the column knows its origin
+    # We still need to prefix the table name to the column name in the final
+    # query, so make sure the column knows its origin
     array.table = raw.table
 
     array_length = sa.func.cardinality(array)

--- a/ibis/sql/postgres/compiler.py
+++ b/ibis/sql/postgres/compiler.py
@@ -471,8 +471,12 @@ def _array_repeat(t, expr):
 
     array_length = sa.func.cardinality(array)
 
-    # sequence from 1 to the total number of elements desired
-    series = sa.func.generate_series(1, times * array_length).alias()
+    # sequence from 1 to the total number of elements desired in steps of 1.
+    # the call to greatest isn't necessary, but it provides clearer intent
+    # rather than depending on the implicit postgres generate_series behavior
+    start = step = 1
+    stop = sa.func.greatest(times, 0) * array_length
+    series = sa.func.generate_series(start, stop, step).alias()
     series_column = sa.column(series.name, type_=sa.INTEGER)
 
     # if our current index modulo the array's length

--- a/ibis/sql/postgres/tests/test_functions.py
+++ b/ibis/sql/postgres/tests/test_functions.py
@@ -654,3 +654,29 @@ class TestPostgreSQLFunctions(PostgreSQLTests, unittest.TestCase):
         expected = df.assign(new_col=[x / 2. for x in range(len(df))])
         result = expr['timestamp_col', 'new_col'].execute()
         tm.assert_frame_equal(result, expected)
+
+
+@pytest.fixture
+def con():
+    return ibis.postgres.connect(host='localhost', database='ibis_testing')
+
+
+@pytest.fixture
+def array_types(con):
+    return con.table('array_types')
+
+
+def test_array_length(array_types):
+    expr = array_types.projection([
+        array_types.x.length().name('x_length'),
+        array_types.y.length().name('y_length'),
+        array_types.z.length().name('z_length'),
+    ])
+    result = expr.execute()
+    expected = pd.DataFrame({
+        'x_length': [3, 5, 3],
+        'y_length': [3, 5, 5],
+        'z_length': [3, 5, None],
+    })
+
+    tm.assert_frame_equal(result, expected)

--- a/ibis/sql/postgres/tests/test_functions.py
+++ b/ibis/sql/postgres/tests/test_functions.py
@@ -712,6 +712,27 @@ def test_array_collect(array_types):
         (1, 1),
         (2, 3),
         (2, 5),
+
+        (None, 3),
+        (None, None),
+        (3, None),
+
+        # negative slices are not supported
+        pytest.mark.xfail(
+            (-3, None),
+            raises=ValueError,
+            reason='Negative slicing not supported'
+        ),
+        pytest.mark.xfail(
+            (None, -3),
+            raises=ValueError,
+            reason='Negative slicing not supported'
+        ),
+        pytest.mark.xfail(
+            (-3, -1),
+            raises=ValueError,
+            reason='Negative slicing not supported'
+        ),
     ]
 )
 def test_array_slice(array_types, start, stop):

--- a/ibis/sql/postgres/tests/test_functions.py
+++ b/ibis/sql/postgres/tests/test_functions.py
@@ -759,16 +759,5 @@ def test_array_concat(array_types):
 
 
 def test_array_concat_mixed_types(array_types):
-    """TODO: test for API misuse like ARRAY[STRING] + ARRAY[NOT STRING]
-    """
-    expr = array_types.projection([
-        (array_types.x + array_types.x.cast('array<double>')).name('catted')
-    ])
-    assert expr.type() == dt.Array(dt.double)
-    result = expr.execute()
-    expected = pd.DataFrame({
-        'catted': array_types.x.execute().map(
-            lambda x: x + list(map(float, x))
-        )
-    })
-    tm.assert_frame_equal(result, expected)
+    with pytest.raises(TypeError):
+        array_types.x + array_types.x.cast('array<double>')

--- a/ibis/sql/postgres/tests/test_functions.py
+++ b/ibis/sql/postgres/tests/test_functions.py
@@ -746,8 +746,6 @@ def test_array_repeat(array_types, n):
 
 
 def test_array_concat(array_types):
-    """TODO: test for API misuse like ARRAY[STRING] + ARRAY[NOT STRING]
-    """
     expr = array_types.projection([
         (array_types.x + array_types.x).name('catted')
     ])

--- a/ibis/sql/postgres/tests/test_functions.py
+++ b/ibis/sql/postgres/tests/test_functions.py
@@ -756,20 +756,7 @@ def test_array_index(array_types, index):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    'n',
-    [
-        1,
-        3,
-        4,
-        7,
-        pytest.mark.xfail(
-            -2,
-            raises=ValueError,
-            reason='Negative repeat does not make sense'
-        )
-    ]
-)
+@pytest.mark.parametrize('n', [1, 3, 4, 7, -2])
 @pytest.mark.parametrize('mul', [lambda x, n: x * n, lambda x, n: n * x])
 def test_array_repeat(array_types, n, mul):
     expr = array_types.projection([mul(array_types.x, n).name('repeated')])


### PR DESCRIPTION
This PR fills out array types a bit more by adding the following operations

Closes #851 

1. `length`
2. `collect` (an aggregate function that collects column elements into an array)
3. `+` (concatenates two arrays)
4. `*` (similar to Python `list`s, this operation repeats the list a specified number of times)