### PR TITLE
Allow projections of analytic columns

### DIFF
--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1734,18 +1734,7 @@ class Selection(TableNode, HasSchema):
         if self.equals(other):
             return True
 
-        table = self.table
-        exist_layers = False
-        op = table.op()
-        while not (op.blocks() or isinstance(op, Join)):
-            table = table.op().table
-            exist_layers = True
-
-        if exist_layers:
-            reboxed = Selection(table, self.selections)
-            return reboxed.is_ancestor(other)
-        else:
-            return False
+        return False
 
     # Operator combination / fusion logic
 

--- a/ibis/expr/tests/test_analysis.py
+++ b/ibis/expr/tests/test_analysis.py
@@ -301,3 +301,14 @@ def test_join_table_choice():
     t = x.aggregate(cnt=x.n.count())
     predicate = t.cnt > 0
     assert L.sub_for(predicate, [(t, t.op().table)]).equals(predicate)
+
+
+def test_is_ancestor_analytic():
+    x = ibis.table(ibis.schema([('col', 'int32')]), 'x')
+    with_filter_col = x[x.columns + [ibis.null().name('filter')]]
+    filtered = with_filter_col[with_filter_col['filter'].isnull()]
+    subquery = filtered[filtered.columns]
+
+    with_analytic = subquery[subquery.columns + [subquery.count().name('analytic')]]
+
+    assert not subquery.op().is_ancestor(with_analytic)


### PR DESCRIPTION
This seems to fix https://github.com/cloudera/ibis/issues/900

Doesn't seem to be a very satisfactory fix because it removes a bunch of logic. All the tests still pass though.

I'm unsure of the original intentions of that logic because the if exist_layers: was never able to evaluate True as it's only set to True in the while loop. The while loop has non changing conditions so it would just error out if the loop was entered.