### PR TITLE
Speed up compiling many nested subqueries

### DIFF
--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -770,7 +770,6 @@ class _CorrelatedRefCheck(object):
 
         node = expr.op()
 
-
         if isinstance(node, (ops.PhysicalTable, ops.SelfReference)):
             self._ref_check(node, in_subquery=in_subquery)
 

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -728,16 +728,23 @@ class _CorrelatedRefCheck(object):
         self._visit(self.expr)
         return self.has_query_root and self.has_foreign_root
 
-    def _visit(self, expr, in_subquery=False):
+    def _visit(self, expr, in_subquery=False, visit_cache=None, visit_table_cache=None):
+        if visit_cache is None:
+            visit_cache = set()
+
+        if (id(expr), in_subquery) in visit_cache:
+            return
+        visit_cache.add((id(expr), in_subquery))
+
         node = expr.op()
 
         in_subquery = in_subquery or self._is_subquery(node)
 
         for arg in node.flat_args():
             if isinstance(arg, ir.TableExpr):
-                self._visit_table(arg, in_subquery=in_subquery)
+                self._visit_table(arg, in_subquery=in_subquery, visit_cache=visit_cache, visit_table_cache=visit_table_cache)
             elif isinstance(arg, ir.Expr):
-                self._visit(arg, in_subquery=in_subquery)
+                self._visit(arg, in_subquery=in_subquery, visit_cache=visit_cache, visit_table_cache=visit_table_cache)
             else:
                 continue
 
@@ -753,15 +760,23 @@ class _CorrelatedRefCheck(object):
 
         return False
 
-    def _visit_table(self, expr, in_subquery=False):
+    def _visit_table(self, expr, in_subquery=False, visit_cache=None, visit_table_cache=None):
+        if visit_table_cache is None:
+            visit_table_cache = set()
+
+        if (id(expr), in_subquery) in visit_table_cache:
+            return
+        visit_table_cache.add((id(expr), in_subquery))
+
         node = expr.op()
+
 
         if isinstance(node, (ops.PhysicalTable, ops.SelfReference)):
             self._ref_check(node, in_subquery=in_subquery)
 
         for arg in node.flat_args():
             if isinstance(arg, ir.Expr):
-                self._visit(arg, in_subquery=in_subquery)
+                self._visit(arg, in_subquery=in_subquery, visit_cache=visit_cache, visit_table_cache=visit_table_cache)
 
     def _ref_check(self, node, in_subquery=False):
         is_aliased = self.ctx.has_ref(node)

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -728,7 +728,8 @@ class _CorrelatedRefCheck(object):
         self._visit(self.expr)
         return self.has_query_root and self.has_foreign_root
 
-    def _visit(self, expr, in_subquery=False, visit_cache=None, visit_table_cache=None):
+    def _visit(self, expr, in_subquery=False, visit_cache=None,
+               visit_table_cache=None):
         if visit_cache is None:
             visit_cache = set()
 
@@ -742,9 +743,13 @@ class _CorrelatedRefCheck(object):
 
         for arg in node.flat_args():
             if isinstance(arg, ir.TableExpr):
-                self._visit_table(arg, in_subquery=in_subquery, visit_cache=visit_cache, visit_table_cache=visit_table_cache)
+                self._visit_table(arg, in_subquery=in_subquery,
+                                  visit_cache=visit_cache,
+                                  visit_table_cache=visit_table_cache)
             elif isinstance(arg, ir.Expr):
-                self._visit(arg, in_subquery=in_subquery, visit_cache=visit_cache, visit_table_cache=visit_table_cache)
+                self._visit(arg, in_subquery=in_subquery,
+                            visit_cache=visit_cache,
+                            visit_table_cache=visit_table_cache)
             else:
                 continue
 
@@ -760,7 +765,8 @@ class _CorrelatedRefCheck(object):
 
         return False
 
-    def _visit_table(self, expr, in_subquery=False, visit_cache=None, visit_table_cache=None):
+    def _visit_table(self, expr, in_subquery=False, visit_cache=None,
+                     visit_table_cache=None):
         if visit_table_cache is None:
             visit_table_cache = set()
 
@@ -775,7 +781,9 @@ class _CorrelatedRefCheck(object):
 
         for arg in node.flat_args():
             if isinstance(arg, ir.Expr):
-                self._visit(arg, in_subquery=in_subquery, visit_cache=visit_cache, visit_table_cache=visit_table_cache)
+                self._visit(arg, in_subquery=in_subquery,
+                            visit_cache=visit_cache,
+                            visit_table_cache=visit_table_cache)
 
     def _ref_check(self, node, in_subquery=False):
         is_aliased = self.ctx.has_ref(node)


### PR DESCRIPTION
I ran into this after https://github.com/cloudera/ibis/pull/901 . When you have queries that have many levels of subqueries the compiling time starts to increase drastically. By caching the graph traversal, the compile time is decreased.

This includes the mentioned pr https://github.com/cloudera/ibis/pull/901 . I can merge this into that pr if that makes more sense. I figured it might be helpful to split the bug fix up from the improvement.

```python
# example_fail.py
import ibis

def add_filter_and_ana(t):
    t = t[t.columns + [ibis.null().name('filter')]]

    t = t[t['filter'].isnull()]

    t = t[['col']]

    t = t[t.columns + [t.count().name('analytic')]]

    t = t[t.columns]
    t = t[t['analytic'] < 0]
    t = t[['col']]
    return t

t = ibis.table((('col', 'int32'), ), name='t')

for _ in range(4):
    t = add_filter_and_ana(t)

ibis.impala.compile(t)
```

```
root@582f1eb935bd:/ibis/ibis# git checkout fix-analytic-projection
Already on 'fix-analytic-projection'
Your branch is up-to-date with 'origin/fix-analytic-projection'.
root@582f1eb935bd:/ibis/ibis# time python example_fail.py                                                                                                                                                          

real    0m10.935s
user    0m10.828s
sys     0m0.096s
root@582f1eb935bd:/ibis/ibis# git checkout fast-visit
Switched to branch 'fast-visit'
root@582f1eb935bd:/ibis/ibis# time python example_fail.py

real    0m0.535s
user    0m0.456s
sys     0m0.072s
```