### PR TITLE
ENH: Add instance_of type validator, flake8 cleanup, type signature validation in base Node class

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -85,7 +85,6 @@ class ScalarAggregate(object):
             name = self.default_name
             named_expr = subbed_expr.name(self.default_name)
 
-        tables = list(self.memo.values())
         table = self.tables[0]
         for other in self.tables[1:]:
             table = table.cross_join(other)
@@ -267,7 +266,7 @@ class ExprSimplifier(object):
 
         op = expr.op()
 
-        if isinstance(op, ops.ValueNode):
+        if isinstance(op, ops.ValueOp):
             return self._sub(expr, block=block)
         elif isinstance(op, ops.Selection):
             result = self._lift_Selection(expr, block=block)

--- a/ibis/expr/analytics.py
+++ b/ibis/expr/analytics.py
@@ -19,7 +19,7 @@ import ibis.expr.rules as rules
 import ibis.expr.operations as ops
 
 
-class BucketLike(ir.ValueNode):
+class BucketLike(ir.ValueOp):
 
     def _validate_closed(self, closed):
         closed = closed.lower()
@@ -55,9 +55,9 @@ class Bucket(BucketLike):
                 raise ValueError('If one bucket edge provided, must have'
                                  ' include_under=True and include_over=True')
 
-        ir.ValueNode.__init__(self, self.arg, self.buckets, self.closed,
-                              self.close_extreme, self.include_under,
-                              self.include_over)
+        ir.ValueOp.__init__(self, self.arg, self.buckets, self.closed,
+                            self.close_extreme, self.include_under,
+                            self.include_over)
 
     @property
     def nbuckets(self):
@@ -85,8 +85,8 @@ class Histogram(BucketLike):
         self.closed = self._validate_closed(closed)
 
         self.aux_hash = aux_hash
-        ir.ValueNode.__init__(self, self.arg, self.nbins, self.binwidth,
-                              self.base, self.closed, self.aux_hash)
+        ir.ValueOp.__init__(self, self.arg, self.nbins, self.binwidth,
+                            self.base, self.closed, self.aux_hash)
 
     def output_type(self):
         # always undefined cardinality (for now)
@@ -94,7 +94,7 @@ class Histogram(BucketLike):
         return ctype.array_type()
 
 
-class CategoryLabel(ir.ValueNode):
+class CategoryLabel(ir.ValueOp):
 
     def __init__(self, arg, labels, nulls):
         self.arg = ops.as_value_expr(arg)
@@ -106,7 +106,7 @@ class CategoryLabel(ir.ValueNode):
                              'categories: %d' % card)
 
         self.nulls = nulls
-        ir.ValueNode.__init__(self, self.arg, self.labels, self.nulls)
+        ir.ValueOp.__init__(self, self.arg, self.labels, self.nulls)
 
     def output_type(self):
         return rules.shape_like(self.arg, 'string')

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1599,7 +1599,8 @@ def _array_slice(array, index):
     if isinstance(index, slice):
         start = index.start
         stop = index.stop
-        if (start is not None and start < 0) or (stop is not None and stop < 0):
+        if ((start is not None and start < 0) or
+                (stop is not None and stop < 0)):
             raise ValueError('negative slicing not yet supported')
 
         step = index.step

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -391,15 +391,15 @@ class Category(DataType):
         cardinality = self.cardinality
 
         if cardinality is None:
-            return dt.int64
-        elif cardinality < dt.int8.bounds.upper:
-            return dt.int8
-        elif cardinality < dt.int16.bounds.upper:
-            return dt.int16
-        elif cardinality < dt.int32.bounds.upper:
-            return dt.int32
+            return int64
+        elif cardinality < int8.bounds.upper:
+            return int8
+        elif cardinality < int16.bounds.upper:
+            return int16
+        elif cardinality < int32.bounds.upper:
+            return int32
         else:
-            return dt.int64
+            return int64
 
 
 @parametric
@@ -425,7 +425,9 @@ class Struct(DataType):
         )
 
     def __eq__(self, other):
-        return isinstance(other, type(self)) and self.names == other.names and self.types == other.types
+        return (isinstance(other, type(self)) and
+                self.names == other.names and
+                self.types == other.types)
 
     @classmethod
     def from_tuples(self, pairs):

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -1,4 +1,3 @@
-import queue as q
 from itertools import chain
 from toolz import identity
 from collections import deque
@@ -14,7 +13,8 @@ def roots(expr, types=(ops.PhysicalTable,)):
     ----------
     expr : Expr
         The expression to analyze
-    types : tuple(type), optional, default (:mod:`ibis.expr.operations.PhysicalTable`,)
+    types : tuple(type), optional, default
+            (:mod:`ibis.expr.operations.PhysicalTable`,)
         The node types to traverse
 
     Yields

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -638,6 +638,11 @@ def one_of(args, **arg_kwds):
     return OneOf(args, **arg_kwds)
 
 
+def instance_of(type_, **arg_kwds):
+    fail_message = 'not a {0}'.format(str(type_))
+    return AnyTyped(type_, fail_message, **arg_kwds)
+
+
 class StringOptions(Argument):
 
     def __init__(self, options, **arg_kwds):

--- a/ibis/expr/tests/conftest.py
+++ b/ibis/expr/tests/conftest.py
@@ -17,7 +17,6 @@ from ibis.expr.tests.mocks import MockConnection
 
 import pytest
 import ibis
-import ibis.expr.datatypes as dt
 
 
 @pytest.fixture

--- a/ibis/expr/tests/mocks.py
+++ b/ibis/expr/tests/mocks.py
@@ -14,7 +14,6 @@
 
 from ibis.client import SQLClient
 from ibis.expr.datatypes import Schema
-import ibis
 
 
 class MockConnection(SQLClient):

--- a/ibis/expr/tests/test_analysis.py
+++ b/ibis/expr/tests/test_analysis.py
@@ -16,7 +16,6 @@ import pytest
 
 import ibis
 
-from ibis.compat import unittest
 import ibis.expr.analysis as L
 import ibis.expr.operations as ops
 import ibis.common as com
@@ -309,6 +308,7 @@ def test_is_ancestor_analytic():
     filtered = with_filter_col[with_filter_col['filter'].isnull()]
     subquery = filtered[filtered.columns]
 
-    with_analytic = subquery[subquery.columns + [subquery.count().name('analytic')]]
+    with_analytic = subquery[subquery.columns +
+                             [subquery.count().name('analytic')]]
 
     assert not subquery.op().is_ancestor(with_analytic)

--- a/ibis/expr/tests/test_decimal.py
+++ b/ibis/expr/tests/test_decimal.py
@@ -16,11 +16,10 @@ import ibis.expr.api as api
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
 
-from ibis.compat import unittest
 from ibis.expr.tests.mocks import MockConnection
 
-
 import pytest
+
 
 @pytest.fixture
 def con():

--- a/ibis/expr/tests/test_format.py
+++ b/ibis/expr/tests/test_format.py
@@ -38,7 +38,6 @@ class TestExprFormatting(unittest.TestCase):
         self.table = ibis.table(self.schema)
         self.con = MockConnection()
 
-
     def test_format_custom_expr(self):
         from ibis.expr.types import Expr, Literal
 

--- a/ibis/expr/tests/test_lineage.py
+++ b/ibis/expr/tests/test_lineage.py
@@ -64,7 +64,8 @@ def test_lineage(companies):
 
     grouped = filtered.group_by(['bucket', 'status']).size()
 
-    joined = grouped.mutate(
+    # TODO(cpcloud): Should this be used?
+    joined = grouped.mutate(  # noqa
         bucket_name=lambda x: x.bucket.label(bucket_names).fillna('Unknown')
     )
 

--- a/ibis/expr/tests/test_table.py
+++ b/ibis/expr/tests/test_table.py
@@ -22,9 +22,6 @@ import ibis.expr.types as ir
 import ibis.expr.operations as ops
 import ibis
 
-from ibis.compat import unittest
-from ibis.expr.tests.mocks import MockConnection
-
 import ibis.common as com
 import ibis.config as config
 
@@ -461,7 +458,7 @@ def test_sum_expr_basics(table, int_col):
     # Impala gives bigint for all integer types
     ex_class = api.Int64Scalar
     result = table[int_col].sum()
-    assert isinstance(result, api.Int64Scalar)
+    assert isinstance(result, ex_class)
     assert isinstance(result.op(), ops.Sum)
 
 
@@ -469,7 +466,7 @@ def test_sum_expr_basics_floats(table, float_col):
     # Impala gives double for all floating point types
     ex_class = api.DoubleScalar
     result = table[float_col].sum()
-    assert isinstance(result, api.DoubleScalar)
+    assert isinstance(result, ex_class)
     assert isinstance(result.op(), ops.Sum)
 
 
@@ -1142,7 +1139,7 @@ def test_filter(table):
     assert_equal(result, expected)
 
 
-def test_sort_by(table):
+def test_sort_by2(table):
     m = table.mutate(foo=table.e + table.f)
 
     result = m.sort_by(lambda x: -x.foo)
@@ -1158,7 +1155,7 @@ def test_sort_by(table):
     assert_equal(result, expected)
 
 
-def test_projection(table):
+def test_projection2(table):
     m = table.mutate(foo=table.f * 2)
 
     def f(x):
@@ -1171,7 +1168,7 @@ def test_projection(table):
     assert_equal(result2, expected)
 
 
-def test_mutate(table):
+def test_mutate2(table):
     m = table.mutate(foo=table.f * 2)
 
     def g(x):
@@ -1188,7 +1185,7 @@ def test_mutate(table):
     assert_equal(result, expected)
 
 
-def test_add_column(table):
+def test_add_column2(table):
     def g(x):
         return x.f * 2
 

--- a/ibis/expr/tests/test_value_exprs.py
+++ b/ibis/expr/tests/test_value_exprs.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import itertools
 import operator
 
 import pytest
@@ -23,8 +22,6 @@ import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
 import ibis
-
-from ibis.compat import unittest
 
 from ibis.tests.util import assert_equal
 
@@ -442,7 +439,8 @@ def test_boolean_comparisons(table):
 
 @pytest.mark.parametrize(
     'operation',
-    [operator.lt, operator.gt, operator.ge, operator.le, operator.eq, operator.ne]
+    [operator.lt, operator.gt, operator.ge, operator.le,
+     operator.eq, operator.ne]
 )
 def test_string_comparisons(table, operation):
     string_col = table.g

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -140,17 +140,19 @@ class Window(object):
             return False
 
         if (len(self._group_by) != len(other._group_by) or
-                not ir.all_equal(self._group_by, other._group_by, cache=cache)):
+                not ir.all_equal(self._group_by, other._group_by,
+                                 cache=cache)):
             cache[(self, other)] = False
             return False
 
         if (len(self._order_by) != len(other._order_by) or
-                not ir.all_equal(self._order_by, other._order_by, cache=cache)):
+                not ir.all_equal(self._order_by, other._order_by,
+                                 cache=cache)):
             cache[(self, other)] = False
             return False
 
         equal = (self.preceding == other.preceding and
-                self.following == other.following)
+                 self.following == other.following)
         cache[(self, other)] = equal
         return equal
 

--- a/ibis/impala/tests/conftest.py
+++ b/ibis/impala/tests/conftest.py
@@ -13,4 +13,3 @@
 # limitations under the License.
 
 from ibis.tests.conftest import *  # noqa
-from ibis.expr.tests.conftest import con

--- a/ibis/impala/tests/test_ddl.py
+++ b/ibis/impala/tests/test_ddl.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa=E402
+
 from copy import copy
 import gc
 

--- a/ibis/impala/tests/test_exprs.py
+++ b/ibis/impala/tests/test_exprs.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa=E402
+
 import pytest
 
 pytest.importorskip('sqlalchemy')

--- a/ibis/impala/tests/test_kudu_support.py
+++ b/ibis/impala/tests/test_kudu_support.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa=E402
+
 import os
 import pytest
 

--- a/ibis/impala/tests/test_partition.py
+++ b/ibis/impala/tests/test_partition.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa=E402
+
 from posixpath import join as pjoin
 import pytest
 

--- a/ibis/impala/tests/test_udf.py
+++ b/ibis/impala/tests/test_udf.py
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa=E402
+
 from posixpath import join as pjoin
 import pytest
 

--- a/ibis/impala/tests/test_window.py
+++ b/ibis/impala/tests/test_window.py
@@ -19,9 +19,18 @@ from ibis import window
 import ibis
 
 from ibis.impala.compiler import to_sql
-from ibis.compat import unittest
+from ibis.impala.tests.common import ImpalaE2E
 from ibis.tests.util import assert_equal
 import ibis.common as com
+
+
+@pytest.yield_fixture(scope='module')
+def con(request):
+    try:
+        ImpalaE2E.setUpClass()
+        yield ImpalaE2E.con
+    finally:
+        ImpalaE2E.tearDownClass()
 
 
 def assert_sql_equal(expr, expected):
@@ -29,6 +38,7 @@ def assert_sql_equal(expr, expected):
     assert result == expected
 
 
+@pytest.mark.impala
 def test_aggregate_in_projection(con):
     t = con.table('alltypes')
     proj = t[t, (t.f / t.f.sum()).name('normed_f')]
@@ -39,6 +49,7 @@ FROM alltypes"""
     assert_sql_equal(proj, expected)
 
 
+@pytest.mark.impala
 def test_add_default_order_by(con):
     t = con.table('alltypes')
 
@@ -59,6 +70,7 @@ FROM alltypes"""
     assert_sql_equal(proj, expected)
 
 
+@pytest.mark.impala
 @pytest.mark.parametrize(
     ['window', 'frame'],
     [
@@ -107,6 +119,7 @@ FROM alltypes"""
     assert_sql_equal(expr, expected)
 
 
+@pytest.mark.impala
 def test_cumulative_functions(con):
     t = con.table('alltypes')
 
@@ -128,6 +141,7 @@ def test_cumulative_functions(con):
         assert to_sql(expr1) == to_sql(expr2)
 
 
+@pytest.mark.impala
 def test_nested_analytic_function(con):
     t = con.table('alltypes')
 
@@ -141,6 +155,7 @@ FROM alltypes"""
     assert_sql_equal(result, expected)
 
 
+@pytest.mark.impala
 def test_rank_functions(con):
     t = con.table('alltypes')
 
@@ -153,6 +168,7 @@ FROM alltypes"""
     assert_sql_equal(proj, expected)
 
 
+@pytest.mark.impala
 def test_multiple_windows(con):
     t = con.table('alltypes')
 
@@ -167,6 +183,7 @@ FROM alltypes"""
     assert_sql_equal(proj, expected)
 
 
+@pytest.mark.impala
 def test_order_by_desc(con):
     t = con.table('alltypes')
 
@@ -188,6 +205,7 @@ FROM alltypes"""
     assert_sql_equal(expr, expected)
 
 
+@pytest.mark.impala
 def test_row_number_requires_order_by(con):
     t = con.table('alltypes')
 
@@ -205,6 +223,7 @@ FROM alltypes"""
     assert_sql_equal(expr, expected)
 
 
+@pytest.mark.impala
 def test_row_number_properly_composes_with_arithmetic(con):
     t = con.table('alltypes')
     w = ibis.window(order_by=t.f)
@@ -216,6 +235,7 @@ FROM alltypes"""
     assert_sql_equal(expr, expected)
 
 
+@pytest.mark.impala
 @pytest.mark.parametrize(
     ['column', 'op'],
     [
@@ -233,6 +253,7 @@ def test_unsupported_aggregate_functions(con, column, op):
         to_sql(proj)
 
 
+@pytest.mark.impala
 def test_propagate_nested_windows(con):
     # GH #469
     t = con.table('alltypes')

--- a/ibis/impala/udf.py
+++ b/ibis/impala/udf.py
@@ -14,7 +14,6 @@
 import re
 
 from ibis.expr.datatypes import validate_type
-import ibis.expr.datatypes as _dt
 import ibis.expr.operations as _ops
 import ibis.expr.rules as rules
 import ibis.impala.compiler as comp

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -182,7 +182,7 @@ class SelectBuilder(object):
 
         unchanged = True
 
-        if isinstance(op, ops.ValueNode):
+        if isinstance(op, ops.ValueOp):
             new_args = []
             for arg in op.args:
                 if isinstance(arg, ir.Expr):
@@ -276,7 +276,7 @@ class SelectBuilder(object):
         elif isinstance(op, (ops.Any, ops.BooleanValueOp,
                              ops.TableColumn, ir.Literal)):
             return expr
-        elif isinstance(op, ops.ValueNode):
+        elif isinstance(op, ops.ValueOp):
             visited = [self._visit_filter(arg)
                        if isinstance(arg, ir.Expr) else arg
                        for arg in op.args]
@@ -642,7 +642,7 @@ class _ExtractSubqueries(object):
             self._visit_join(expr)
         elif isinstance(node, ops.PhysicalTable):
             self._visit_physical_table(expr)
-        elif isinstance(node, ops.ValueNode):
+        elif isinstance(node, ops.ValueOp):
             for arg in node.flat_args():
                 if not isinstance(arg, ir.Expr):
                     continue
@@ -1437,7 +1437,8 @@ class TableSetFormatter(object):
 
 class Union(DDL):
 
-    def __init__(self, left_table, right_table, expr, distinct=False, context=None):
+    def __init__(self, left_table, right_table, expr, distinct=False,
+                 context=None):
         self.context = context
         self.left = left_table
         self.right = right_table

--- a/ibis/sql/postgres/compiler.py
+++ b/ibis/sql/postgres/compiler.py
@@ -285,7 +285,8 @@ def _strftime(t, expr):
 
 
 def _distinct_from(a, b):
-    return ((a is not None) | (b is not None)) & sa.func.coalesce(a != b, True)
+    return (((a != None) | (b != None)) &  # noqa
+            sa.func.coalesce(a != b, True))
 
 
 def _find_in_set(t, expr):

--- a/ibis/sql/postgres/tests/common.py
+++ b/ibis/sql/postgres/tests/common.py
@@ -21,7 +21,7 @@ pytest.importorskip('sqlalchemy')
 pytest.importorskip('psycopg2')
 
 
-from sqlalchemy.dialects.postgresql import dialect as postgres_dialect
+from sqlalchemy.dialects.postgresql import dialect as postgres_dialect  # noqa
 
 
 PG_USER = os.environ.get('IBIS_POSTGRES_USER', getpass.getuser())

--- a/ibis/sql/postgres/tests/test_functions.py
+++ b/ibis/sql/postgres/tests/test_functions.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa=E402
+
 import math
 import os
 import uuid
-import os
 
 import pytest  # noqa
 
@@ -33,6 +34,7 @@ import pandas as pd
 import pandas.util.testing as tm
 
 
+@pytest.mark.postgresql
 class TestPostgreSQLFunctions(PostgreSQLTests, unittest.TestCase):
 
     def test_cast(self):
@@ -670,6 +672,7 @@ def array_types(con):
     return con.table('array_types')
 
 
+@pytest.mark.postgresql
 def test_array_length(array_types):
     expr = array_types.projection([
         array_types.x.length().name('x_length'),
@@ -686,12 +689,14 @@ def test_array_length(array_types):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.postgresql
 def test_array_schema(array_types):
     assert array_types.x.type() == dt.Array(dt.int64)
     assert array_types.y.type() == dt.Array(dt.string)
     assert array_types.z.type() == dt.Array(dt.double)
 
 
+@pytest.mark.postgresql
 def test_array_collect(array_types):
     expr = array_types.group_by(
         array_types.grouper
@@ -704,6 +709,7 @@ def test_array_collect(array_types):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.postgresql
 @pytest.mark.parametrize(
     ['start', 'stop'],
     [
@@ -743,6 +749,7 @@ def test_array_slice(array_types, start, stop):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.postgresql
 @pytest.mark.parametrize('index', [1, 3, 4, 11])
 def test_array_index(array_types, index):
     expr = array_types[array_types.y[index].name('indexed')]
@@ -755,6 +762,7 @@ def test_array_index(array_types, index):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.postgresql
 @pytest.mark.parametrize('n', [1, 3, 4, 7, -2])
 @pytest.mark.parametrize('mul', [lambda x, n: x * n, lambda x, n: n * x])
 def test_array_repeat(array_types, n, mul):
@@ -764,6 +772,7 @@ def test_array_repeat(array_types, n, mul):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.postgresql
 @pytest.mark.parametrize('catop', [lambda x, y: x + y, lambda x, y: y + x])
 def test_array_concat(array_types, catop):
     t = array_types
@@ -775,11 +784,13 @@ def test_array_concat(array_types, catop):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.postgresql
 def test_array_concat_mixed_types(array_types):
     with pytest.raises(TypeError):
         array_types.x + array_types.x.cast('array<double>')
 
 
+@pytest.mark.postgresql
 @pytest.yield_fixture
 def t(con):
     name = 'left_t'
@@ -797,6 +808,7 @@ def t(con):
         con.drop_table(name)
 
 
+@pytest.mark.postgresql
 @pytest.yield_fixture
 def s(con, t):
     name = 'right_t'
@@ -815,6 +827,7 @@ def s(con, t):
         con.drop_table(name)
 
 
+@pytest.mark.postgresql
 @pytest.yield_fixture
 def trunc(con):
     name = str(uuid.uuid1())
@@ -835,6 +848,7 @@ def trunc(con):
         con.drop_table(name)
 
 
+@pytest.mark.postgresql
 def test_semi_join(t, s):
     t_a, s_a = t.op().sqla_table.alias('t0'), s.op().sqla_table.alias('t1')
     expr = t.semi_join(s, t.id == s.id)
@@ -846,6 +860,7 @@ def test_semi_join(t, s):
     assert str(result) == str(expected)
 
 
+@pytest.mark.postgresql
 def test_anti_join(t, s):
     t_a, s_a = t.op().sqla_table.alias('t0'), s.op().sqla_table.alias('t1')
     expr = t.anti_join(s, t.id == s.id)
@@ -858,6 +873,7 @@ def test_anti_join(t, s):
     assert str(result) == str(expected)
 
 
+@pytest.mark.postgresql
 def test_create_table(con, trunc):
     name = str(uuid.uuid1())
     con.create_table(name, expr=trunc)
@@ -865,6 +881,7 @@ def test_create_table(con, trunc):
     assert list(t.name.execute()) == list('abc')
 
 
+@pytest.mark.postgresql
 def test_truncate_table(con, trunc):
     assert list(trunc.name.execute()) == list('abc')
     con.truncate_table(trunc.op().name)

--- a/ibis/sql/sqlite/tests/common.py
+++ b/ibis/sql/sqlite/tests/common.py
@@ -15,11 +15,9 @@
 import os
 import pytest
 
-import ibis.util as util
-
 pytest.importorskip('sqlalchemy')
 
-from sqlalchemy.dialects.sqlite import dialect as sqlite_dialect
+from sqlalchemy.dialects.sqlite import dialect as sqlite_dialect  # noqa
 
 
 @pytest.mark.sqlite

--- a/ibis/sql/tests/test_compiler.py
+++ b/ibis/sql/tests/test_compiler.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa=E402
+
 import ibis
 
 import pytest

--- a/ibis/sql/tests/test_sqlalchemy.py
+++ b/ibis/sql/tests/test_sqlalchemy.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa=E402
+
 import operator
 
 import pytest

--- a/ibis/tests/test_server.py
+++ b/ibis/tests/test_server.py
@@ -26,9 +26,9 @@ import ibis.compat as compat
 
 # non-POSIX system (e.g. Windows)
 pytestmark = pytest.mark.skipif(
-    compat.PY3
-        or not hasattr(os, 'setpgid')
-        or os.environ.get('CIRCLE_PROJECT_REPONAME') == 'ibis',
+    compat.PY3 or
+    not hasattr(os, 'setpgid') or
+    os.environ.get('CIRCLE_PROJECT_REPONAME') == 'ibis',
     reason='non-POSIX system'
 )
 


### PR DESCRIPTION
I also added appropriate pytest marks so that even if we have the requisite libraries installed, if properly configured Impala or Postgres instances are not running (and we did not pass `--impala` or `--postgresql`) then the test suite still runs fine. 

Close #907