### PR TITLE
REF: Final conversion of Array* to Column*

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -340,27 +340,27 @@ Array methods
 .. autosummary::
    :toctree: generated/
 
-   ArrayExpr.distinct
+   ColumnExpr.distinct
 
-   ArrayExpr.count
-   ArrayExpr.min
-   ArrayExpr.max
-   ArrayExpr.approx_median
-   ArrayExpr.approx_nunique
-   ArrayExpr.group_concat
-   ArrayExpr.nunique
-   ArrayExpr.summary
+   ColumnExpr.count
+   ColumnExpr.min
+   ColumnExpr.max
+   ColumnExpr.approx_median
+   ColumnExpr.approx_nunique
+   ColumnExpr.group_concat
+   ColumnExpr.nunique
+   ColumnExpr.summary
 
-   ArrayExpr.value_counts
+   ColumnExpr.value_counts
 
-   ArrayExpr.first
-   ArrayExpr.last
-   ArrayExpr.dense_rank
-   ArrayExpr.rank
-   ArrayExpr.lag
-   ArrayExpr.lead
-   ArrayExpr.cummin
-   ArrayExpr.cummax
+   ColumnExpr.first
+   ColumnExpr.last
+   ColumnExpr.dense_rank
+   ColumnExpr.rank
+   ColumnExpr.lag
+   ColumnExpr.lead
+   ColumnExpr.cummin
+   ColumnExpr.cummax
 
 General numeric methods
 -----------------------

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -911,7 +911,7 @@ class FilterValidator(ExprValidator):
                 elif isinstance(arg, ops.TopKExpr):
                     # TopK not subjected to further analysis for now
                     roots_valid.append(True)
-                elif isinstance(arg, (ir.ArrayExpr, ir.AnalyticExpr)):
+                elif isinstance(arg, (ir.ColumnExpr, ir.AnalyticExpr)):
                     roots_valid.append(self.shares_some_roots(arg))
                 elif isinstance(arg, ir.Expr):
                     raise NotImplementedError

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -17,7 +17,7 @@ import toolz
 
 from ibis.expr.datatypes import Schema  # noqa
 from ibis.expr.types import (Expr,  # noqa
-                             ValueExpr, ScalarExpr, ArrayExpr,
+                             ValueExpr, ScalarExpr, ColumnExpr,
                              TableExpr,
                              NumericValue, NumericColumn,
                              IntegerValue,
@@ -981,7 +981,7 @@ _generic_column_methods = dict(
 
 
 _add_methods(ValueExpr, _generic_value_methods)
-_add_methods(ArrayExpr, _generic_column_methods)
+_add_methods(ColumnExpr, _generic_column_methods)
 
 
 # ---------------------------------------------------------------------

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -133,7 +133,7 @@ def lineage(expr, container=Stack):
     ----------
     expr : Expr
         An ibis expression. It must be an instance of
-        :class:`ibis.expr.types.ArrayExpr`.
+        :class:`ibis.expr.types.ColumnExpr`.
     container : Container, {Stack, Queue}
         Stack for depth-first traversal, and Queue for breadth-first.
         Depth-first will reach root table nodes before continuing on to other
@@ -146,8 +146,8 @@ def lineage(expr, container=Stack):
     node : Expr
         A column and its dependencies
     """
-    if not isinstance(expr, ir.ArrayExpr):
-        raise TypeError('Input expression must be an instance of ArrayExpr')
+    if not isinstance(expr, ir.ColumnExpr):
+        raise TypeError('Input expression must be an instance of ColumnExpr')
 
     c = container([(expr, expr._name)])
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -21,7 +21,7 @@ from ibis.compat import py_string
 from ibis.expr.datatypes import HasSchema, Schema
 from ibis.expr.rules import value, string, number, integer, boolean, list_of
 from ibis.expr.types import (Node, as_value_expr, Expr,
-                             ValueExpr, ArrayExpr, TableExpr,
+                             ValueExpr, ColumnExpr, TableExpr,
                              ValueOp, _safe_repr)
 import ibis.common as com
 import ibis.expr.datatypes as dt
@@ -2055,7 +2055,7 @@ class Contains(BooleanValueOp):
         options = self.options.op()
         if isinstance(options, ir.ValueList):
             all_args += options.values
-        elif isinstance(self.options, ArrayExpr):
+        elif isinstance(self.options, ColumnExpr):
             all_args += [self.options]
         else:
             raise TypeError(type(options))
@@ -2136,7 +2136,7 @@ class TopK(ValueOp):
         if by is None:
             by = arg.count()
 
-        if not isinstance(arg, ArrayExpr):
+        if not isinstance(arg, ColumnExpr):
             raise TypeError(arg)
 
         if not isinstance(k, int) or k < 0:

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -235,7 +235,7 @@ def shape_like(arg, out_type):
 
 def shape_like_args(args, out_type):
     out_type = dt.validate_type(out_type)
-    if util.any_of(args, ir.ArrayExpr):
+    if util.any_of(args, ir.ColumnExpr):
         return out_type.array_type()
     else:
         return out_type.scalar_type()
@@ -246,7 +246,7 @@ def is_table(e):
 
 
 def is_array(e):
-    return isinstance(e, ir.ArrayExpr)
+    return isinstance(e, ir.ColumnExpr)
 
 
 def is_scalar(e):
@@ -254,7 +254,7 @@ def is_scalar(e):
 
 
 def is_collection(expr):
-    return isinstance(expr, (ir.ArrayExpr, ir.TableExpr))
+    return isinstance(expr, (ir.ColumnExpr, ir.TableExpr))
 
 
 class Argument(object):
@@ -549,7 +549,7 @@ def value_typed_as(types, **arg_kwds):
 
 
 def array(value_type=None, name=None, optional=False):
-    array_checker = ValueTyped(ir.ArrayExpr, 'not an array expr',
+    array_checker = ValueTyped(ir.ColumnExpr, 'not an array expr',
                                name=name,
                                optional=optional)
     if value_type is None:
@@ -566,7 +566,7 @@ def scalar(name=None, optional=False):
 
 
 def collection(name=None, optional=False):
-    return ValueTyped((ir.ArrayExpr, ir.TableExpr), 'not a collection',
+    return ValueTyped((ir.ColumnExpr, ir.TableExpr), 'not a collection',
                       name=name, optional=optional)
 
 

--- a/ibis/expr/tests/test_format.py
+++ b/ibis/expr/tests/test_format.py
@@ -56,7 +56,7 @@ class TestExprFormatting(unittest.TestCase):
     def test_format_table_column(self):
         # GH #507
         result = repr(self.table.f)
-        assert 'Column[array(double)]' in result
+        assert 'Column[double*]' in result
 
     def test_format_projection(self):
         # This should produce a ref to the projection
@@ -230,8 +230,8 @@ UnboundTable[table]
   schema:
     a : int64
 
-NullIf[array(int64)]
-  a = Column[array(int64)] 'a' from table
+NullIf[int64*]
+  a = Column[int64*] 'a' from table
     ref_0
   null_if_expr:
     Literal[int8]

--- a/ibis/expr/tests/test_table.py
+++ b/ibis/expr/tests/test_table.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from ibis.expr.types import ArrayExpr, TableExpr, RelationError
+from ibis.expr.types import ColumnExpr, TableExpr, RelationError
 from ibis.common import ExpressionError
 from ibis.expr.datatypes import array_type
 import ibis.expr.api as api
@@ -65,7 +65,7 @@ def test_getitem_column_select(table, schema_dict):
         col = table[k]
 
         # Make sure it's the right type
-        assert isinstance(col, ArrayExpr)
+        assert isinstance(col, ColumnExpr)
         assert isinstance(col, array_type(v))
 
         # Ensure we have a field selection with back-reference to the table
@@ -83,7 +83,7 @@ def test_getitem_attribute(table):
     # Project and add a name that conflicts with a TableExpr built-in
     # attribute
     view = table[[table, table['a'].name('schema')]]
-    assert not isinstance(view.schema, ArrayExpr)
+    assert not isinstance(view.schema, ColumnExpr)
 
 
 def test_projection(table):

--- a/ibis/expr/tests/test_value_exprs.py
+++ b/ibis/expr/tests/test_value_exprs.py
@@ -75,7 +75,7 @@ def test_literal_list():
     what = [1, 2, 1000]
     expr = api.as_value_expr(what)
 
-    assert isinstance(expr, ir.ArrayExpr)
+    assert isinstance(expr, ir.ColumnExpr)
     assert isinstance(expr.op(), ir.ValueList)
     assert isinstance(expr.op().values[2], ir.Int16Scalar)
 
@@ -258,7 +258,7 @@ def test_null_literal():
 )
 def test_cumulative_yield_array_types(table, column, operation):
     expr = getattr(getattr(table, column), operation)()
-    assert isinstance(expr, ir.ArrayExpr)
+    assert isinstance(expr, ir.ColumnExpr)
 
 
 @pytest.fixture(params=['ln', 'log', 'log2', 'log10'])

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -579,7 +579,7 @@ class ScalarExpr(ValueExpr):
 class ColumnExpr(ValueExpr):
 
     def _type_display(self):
-        return 'array({0!s})'.format(self.type())
+        return '{}*'.format(self.type())
 
     def parent(self):
         return self._arg

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -576,7 +576,7 @@ class ScalarExpr(ValueExpr):
         return str(self.type())
 
 
-class ArrayExpr(ValueExpr):
+class ColumnExpr(ValueExpr):
 
     def _type_display(self):
         return 'array({0!s})'.format(self.type())
@@ -668,7 +668,7 @@ class TableExpr(Expr):
         elif isinstance(what, BooleanColumn):
             # Boolean predicate
             return self.filter([what])
-        elif isinstance(what, ArrayExpr):
+        elif isinstance(what, ColumnExpr):
             # Projection convenience
             return self.projection(what)
         else:
@@ -769,7 +769,7 @@ class TableExpr(Expr):
         """
         expr = self._ensure_expr(expr)
 
-        if not isinstance(expr, ArrayExpr):
+        if not isinstance(expr, ColumnExpr):
             raise com.InputTypeError('Must pass array expression')
 
         if name is not None:
@@ -983,7 +983,7 @@ class ArrayValue(AnyValue):
         return isinstance(other, ArrayValue)
 
 
-class NumericColumn(ArrayExpr, NumericValue):
+class NumericColumn(ColumnExpr, NumericValue):
     pass
 
 
@@ -994,7 +994,7 @@ class NullScalar(NullValue, ScalarExpr):
     pass
 
 
-class NullColumn(ArrayExpr, NullValue):
+class NullColumn(ColumnExpr, NullValue):
     pass
 
 
@@ -1058,7 +1058,7 @@ class StringScalar(ScalarExpr, StringValue):
     pass
 
 
-class StringColumn(ArrayExpr, StringValue):
+class StringColumn(ColumnExpr, StringValue):
     pass
 
 
@@ -1066,7 +1066,7 @@ class DateScalar(ScalarExpr, DateValue):
     pass
 
 
-class DateColumn(ArrayExpr, DateValue):
+class DateColumn(ColumnExpr, DateValue):
     pass
 
 
@@ -1074,7 +1074,7 @@ class TimestampScalar(ScalarExpr, TimestampValue):
     pass
 
 
-class TimestampColumn(ArrayExpr, TimestampValue):
+class TimestampColumn(ColumnExpr, TimestampValue):
     pass
 
 
@@ -1136,11 +1136,11 @@ class CategoryScalar(CategoryValue, ScalarExpr):
         return factory
 
 
-class CategoryColumn(CategoryValue, ArrayExpr):
+class CategoryColumn(CategoryValue, ColumnExpr):
 
     def __init__(self, arg, meta, name=None):
         CategoryValue.__init__(self, meta)
-        ArrayExpr.__init__(self, arg, name=name)
+        ColumnExpr.__init__(self, arg, name=name)
 
     @property
     def _factory(self):
@@ -1162,11 +1162,11 @@ class ArrayScalar(ArrayValue, ScalarExpr):
         return factory
 
 
-class ArrayColumn(ArrayValue, ArrayExpr):
+class ArrayColumn(ArrayValue, ColumnExpr):
 
     def __init__(self, arg, meta, name=None):
         ArrayValue.__init__(self, meta)
-        ArrayExpr.__init__(self, arg, name=name)
+        ColumnExpr.__init__(self, arg, name=name)
 
     @property
     def _factory(self):
@@ -1266,7 +1266,7 @@ class NullLiteral(ValueOp):
         return []
 
 
-class ListExpr(ArrayExpr, AnyValue):
+class ListExpr(ColumnExpr, AnyValue):
     pass
 
 

--- a/ibis/impala/tests/test_udf.py
+++ b/ibis/impala/tests/test_udf.py
@@ -155,7 +155,7 @@ class TestWrapping(unittest.TestCase):
                                   'int64', 'mult_types')
 
         expr = func(self.i32, self.d, self.s, self.b, self.t)
-        assert issubclass(type(expr), ir.ArrayExpr)
+        assert issubclass(type(expr), ir.ColumnExpr)
 
         expr = func(1, 1.0, 'a', True, ibis.timestamp('1961-04-10'))
         assert issubclass(type(expr), ir.ScalarExpr)
@@ -214,7 +214,7 @@ class TestUDFE2E(ImpalaE2E, unittest.TestCase):
         assert result == Decimal(1)
 
         expr = func(col)
-        assert issubclass(type(expr), ir.ArrayExpr)
+        assert issubclass(type(expr), ir.ColumnExpr)
         self.con.execute(expr)
 
     @pytest.mark.udf
@@ -226,11 +226,11 @@ class TestUDFE2E(ImpalaE2E, unittest.TestCase):
         func = self._udf_creation_to_op(name, symbol, inputs, output)
 
         expr = func(self.alltypes.int_col, 1)
-        assert issubclass(type(expr), ir.ArrayExpr)
+        assert issubclass(type(expr), ir.ColumnExpr)
         self.con.execute(expr)
 
         expr = func(1, self.alltypes.int_col)
-        assert issubclass(type(expr), ir.ArrayExpr)
+        assert issubclass(type(expr), ir.ColumnExpr)
         self.con.execute(expr)
 
         expr = func(self.alltypes.int_col, self.alltypes.tinyint_col)
@@ -262,7 +262,7 @@ class TestUDFE2E(ImpalaE2E, unittest.TestCase):
                 self.assertAlmostEqual(result, self.con.execute(literal), 5)
 
         expr = func(column)
-        assert issubclass(type(expr), ir.ArrayExpr)
+        assert issubclass(type(expr), ir.ColumnExpr)
         self.con.execute(expr)
 
     @pytest.mark.udf

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -861,7 +861,7 @@ def _adapt_expr(expr):
         else:
             raise NotImplementedError(expr._repr())
 
-    elif isinstance(expr, ir.ArrayExpr):
+    elif isinstance(expr, ir.ColumnExpr):
         op = expr.op()
 
         def _get_column(name):


### PR DESCRIPTION
This PR also changes the repr of ArrayExpr to the following:

Old:

```python
Column[array(int64)]
```

New:

```python
Column[int64*]
```