### PR TITLE
Add head method

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1938,12 +1938,12 @@ def _table_distinct(self):
 def _table_limit(table, n, offset=0):
     """
     Select the first n rows at beginning of table (may not be deterministic
-    depending on implementatino and presence of a sorting).
+    depending on implementation and presence of a sorting).
 
     Parameters
     ----------
     n : int
-      Rows to include
+      Number of rows to include
     offset : int, default 0
       Number of rows to skip first
 
@@ -1953,6 +1953,27 @@ def _table_limit(table, n, offset=0):
     """
     op = _ops.Limit(table, n, offset=offset)
     return TableExpr(op)
+
+
+def _head(table, n=5):
+    """
+    Select the first n rows at beginning of a table (may not be deterministic
+    depending on implementation and presence of a sorting).
+
+    Parameters
+    ----------
+    n : int
+      Number of rows to include, defaults to 5
+
+    Returns
+    -------
+    limited : TableExpr
+
+    See Also
+    --------
+    ibis.expr.types.TableExpr.limit
+    """
+    return _table_limit(table, n=n)
 
 
 def _table_sort_by(table, sort_exprs):
@@ -2177,6 +2198,7 @@ _table_methods = dict(
     drop=_table_drop,
     info=_table_info,
     limit=_table_limit,
+    head=_head,
     set_column=_table_set_column,
     filter=filter,
     materialize=_table_materialize,

--- a/ibis/impala/tests/test_exprs.py
+++ b/ibis/impala/tests/test_exprs.py
@@ -20,6 +20,7 @@ pytest.importorskip('sqlalchemy')
 pytest.importorskip('impala.dbapi')
 
 import pandas as pd
+import pandas.util.testing as tm
 
 import ibis
 
@@ -1569,6 +1570,12 @@ FROM functional_alltypes"""
 
         expr = join1.union(join2)
         self.con.explain(expr)
+
+    def test_head(self):
+        t = self.con.table('functional_alltypes')
+        result = t.head().execute()
+        expected = t.limit(5).execute()
+        tm.assert_frame_equal(result, expected)
 
 
 def test_where_with_timestamp():

--- a/ibis/sql/postgres/tests/test_functions.py
+++ b/ibis/sql/postgres/tests/test_functions.py
@@ -800,7 +800,6 @@ def test_array_concat_mixed_types(array_types):
         array_types.x + array_types.x.cast('array<double>')
 
 
-@pytest.mark.postgresql
 @pytest.yield_fixture
 def t(con):
     name = 'left_t'
@@ -818,7 +817,6 @@ def t(con):
         con.drop_table(name)
 
 
-@pytest.mark.postgresql
 @pytest.yield_fixture
 def s(con, t):
     name = 'right_t'
@@ -837,7 +835,6 @@ def s(con, t):
         con.drop_table(name)
 
 
-@pytest.mark.postgresql
 @pytest.yield_fixture
 def trunc(con):
     name = str(uuid.uuid1())
@@ -896,3 +893,11 @@ def test_truncate_table(con, trunc):
     assert list(trunc.name.execute()) == list('abc')
     con.truncate_table(trunc.op().name)
     assert not len(trunc.execute())
+
+
+@pytest.mark.postgresql
+def test_head(con):
+    t = con.table('functional_alltypes')
+    result = t.head().execute()
+    expected = t.limit(5).execute()
+    tm.assert_frame_equal(result, expected)

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -407,6 +407,12 @@ class TestSQLiteFunctions(SQLiteTests, unittest.TestCase):
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_head(self):
+        t = self.alltypes
+        result = t.head().execute()
+        expected = t.limit(5).execute()
+        tm.assert_frame_equal(result, expected)
+
 
 def test_compile_with_named_table():
     t = ibis.table([('a', 'string')], name='t')

--- a/scripts/test_data_admin.py
+++ b/scripts/test_data_admin.py
@@ -130,6 +130,8 @@ def create_test_database(con):
     if con.exists_database(ENV.test_data_db):
         con.drop_database(ENV.test_data_db, force=True)
     con.create_database(ENV.test_data_db)
+    print('Created database {0}'.format(ENV.test_data_db))
+
     con.create_table(
         'alltypes',
         schema=ibis.schema([
@@ -145,7 +147,7 @@ def create_test_database(con):
         ]),
         database=ENV.test_data_db
     )
-    print('Created database {0}'.format(ENV.test_data_db))
+    print('Created empty table {}.`alltypes`'.format(ENV.test_data_db))
 
 
 def create_parquet_tables(con):


### PR DESCRIPTION
Closes #767

This adds a `.head(n=5)` method, implemented as `.limit(n)`. `.head()` is primarily for interactive use, since the more general `.limit` already exists.